### PR TITLE
refactor(email): switch from AWS SES SDK to PHPMailer with SMTP

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,8 @@
       "Bash(composer remove:*)",
       "Bash(vendor\\\\bin\\\\phinx migrate:*)",
       "Bash(dir:*)",
-      "Bash(vendor/bin/phinx migrate:*)"
+      "Bash(vendor/bin/phinx migrate:*)",
+      "Bash(composer update:*)"
     ]
   }
 }

--- a/.env.example
+++ b/.env.example
@@ -8,16 +8,17 @@ DB_PATH=database/jaws.db
 JWT_SECRET=CHANGE_THIS_TO_A_STRONG_SECRET_KEY_MINIMUM_32_CHARACTERS
 JWT_EXPIRATION_MINUTES=60
 
-# AWS SES Configuration
-SES_REGION=ca-central-1
-SES_SMTP_USERNAME=your_ses_username
-SES_SMTP_PASSWORD=your_ses_password
-# SES_ENDPOINT=http://localhost:4566  # Uncomment for LocalStack, leave commented for production AWS
+# SMTP Configuration (PHPMailer)
+SMTP_HOST=email-smtp.ca-central-1.amazonaws.com
+SMTP_PORT=587
+SMTP_SECURE=tls  # Options: tls, ssl, or empty string
+SMTP_USERNAME=your_smtp_username
+SMTP_PASSWORD=your_smtp_password
 
 # Email Configuration
 EMAIL_FROM=noreply@example.com
 EMAIL_FROM_NAME="JAWS System"
-ADMIN_NOTIFICATION_EMAIL=nsc-sdc@nsc.ca
+ADMIN_NOTIFICATION_EMAIL=admin@example.com
 
 # Application Settings
 APP_DEBUG=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,7 +318,7 @@ Presentation → Infrastructure → Application → Domain
   - `SeasonRepository.php` - Implements `SeasonRepositoryInterface` (config & flotilla JSON storage)
 
 - **Service Adapters** (`Service/`)
-  - `AwsSesEmailService.php` - Implements `EmailServiceInterface` using AWS SES via PHPMailer
+  - `PhpMailerEmailService.php` - Implements `EmailServiceInterface` using PHPMailer with SMTP
   - `ICalendarService.php` - Implements `CalendarServiceInterface` using eluceo/ical
   - `SystemTimeService.php` - Implements `TimeServiceInterface` (production/simulated time)
 
@@ -702,12 +702,16 @@ class MyIntegrationTest extends IntegrationTestCase
 - `DB_PATH` - Database file path (default: `database/jaws.db`)
 - `JWT_SECRET` - JWT signing secret (minimum 32 characters, required)
 - `JWT_EXPIRATION_MINUTES` - Token expiration (default: 60)
-- `SES_REGION` - AWS SES region (default: `ca-central-1`)
-- `SES_SMTP_USERNAME` - SMTP credentials
-- `SES_SMTP_PASSWORD` - SMTP credentials
+- `SMTP_HOST` - SMTP server hostname (default: `email-smtp.ca-central-1.amazonaws.com`)
+- `SMTP_PORT` - SMTP server port (default: `587`)
+- `SMTP_SECURE` - SMTP encryption (default: `tls`)
+- `SMTP_USERNAME` - SMTP authentication username
+- `SMTP_PASSWORD` - SMTP authentication password
 - `EMAIL_FROM` - From email address
 - `EMAIL_FROM_NAME` - From name
+- `ADMIN_NOTIFICATION_EMAIL` - Admin email for notifications
 - `APP_DEBUG` - Debug mode (true/false)
+- `APP_ENV` - Environment (production/development)
 - `APP_TIMEZONE` - Timezone (default: `America/Toronto`)
 - `CORS_ALLOWED_ORIGINS` - Comma-separated origins
 - `CORS_ALLOWED_HEADERS` - Comma-separated headers (default: `Content-Type,Authorization`)
@@ -906,7 +910,7 @@ Implementation in `src/Infrastructure/Persistence/SQLite/BoatRepository.php`
 - `src/Infrastructure/Persistence/SQLite/Connection.php`
 - `src/Infrastructure/Persistence/SQLite/BoatRepository.php`
 - `src/Infrastructure/Persistence/SQLite/CrewRepository.php`
-- `src/Infrastructure/Service/AwsSesEmailService.php`
+- `src/Infrastructure/Service/PhpMailerEmailService.php`
 - `src/Infrastructure/Service/ICalendarService.php`
 - `src/Infrastructure/Service/SystemTimeService.php`
 

--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ curl http://localhost:8000/api/events
 
 ### Additional Resources
 
-☁️ **[LocalStack Setup](LocalStack/LOCALSTACK_SETUP.md)** - Testing AWS SES locally
-- Docker setup for LocalStack
-- Email verification
-- Testing notifications without AWS costs
+📧 **Email Testing** - Local SMTP testing
+
+- Use MailHog or similar for local SMTP testing
+- Testing notifications without production email sends
 
 🤖 **[CLAUDE.md](CLAUDE.md)** - AI assistant project guide
 - Complete technical specifications
@@ -153,7 +153,7 @@ Presentation → Infrastructure → Application → Domain
 **Infrastructure Layer** (`src/Infrastructure/`)
 - External service adapters
 - Depends on: Application + Domain layers
-- Contains: Repositories (SQLite), Email Service (AWS SES), Calendar Service, Time Service
+- Contains: Repositories (SQLite), Email Service (PHPMailer/SMTP), Calendar Service, Time Service
 
 **Presentation Layer** (`src/Presentation/`)
 - HTTP/REST API
@@ -311,10 +311,12 @@ DB_PATH=database/jaws.db
 JWT_SECRET=your-secret-key-minimum-32-characters-long
 JWT_EXPIRATION_MINUTES=60
 
-# AWS SES (Email Service)
-SES_REGION=ca-central-1
-SES_SMTP_USERNAME=your_smtp_username
-SES_SMTP_PASSWORD=your_smtp_password
+# SMTP Email Configuration
+SMTP_HOST=email-smtp.ca-central-1.amazonaws.com
+SMTP_PORT=587
+SMTP_SECURE=tls
+SMTP_USERNAME=your_smtp_username
+SMTP_PASSWORD=your_smtp_password
 EMAIL_FROM=noreply@nsc-sdc.ca
 
 # Application

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.1",
         "ext-pdo": "*",
         "ext-pdo_sqlite": "*",
-        "aws/aws-sdk-php": "^3.369",
+        "phpmailer/phpmailer": "^7.0",
         "eluceo/ical": "^2.13",
         "vlucas/phpdotenv": "^5.6"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,159 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c10b70c3e729b9203297eac7537f4c1",
+    "content-hash": "dbce06a61ffe7ee8f3dfbcc2c006f24d",
     "packages": [
-        {
-            "name": "aws/aws-crt-php",
-            "version": "v1.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/awslabs/aws-crt-php.git",
-                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
-                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
-                "yoast/phpunit-polyfills": "^1.0"
-            },
-            "suggest": {
-                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "AWS SDK Common Runtime Team",
-                    "email": "aws-sdk-common-runtime@amazon.com"
-                }
-            ],
-            "description": "AWS Common Runtime for PHP",
-            "homepage": "https://github.com/awslabs/aws-crt-php",
-            "keywords": [
-                "amazon",
-                "aws",
-                "crt",
-                "sdk"
-            ],
-            "support": {
-                "issues": "https://github.com/awslabs/aws-crt-php/issues",
-                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
-            },
-            "time": "2024-10-18T22:15:13+00:00"
-        },
-        {
-            "name": "aws/aws-sdk-php",
-            "version": "3.369.27",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "f844afab2a74eb3cf881970a9c31de460510eb74"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/f844afab2a74eb3cf881970a9c31de460510eb74",
-                "reference": "f844afab2a74eb3cf881970a9c31de460510eb74",
-                "shasum": ""
-            },
-            "require": {
-                "aws/aws-crt-php": "^1.2.3",
-                "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-simplexml": "*",
-                "guzzlehttp/guzzle": "^7.4.5",
-                "guzzlehttp/promises": "^2.0",
-                "guzzlehttp/psr7": "^2.4.5",
-                "mtdowling/jmespath.php": "^2.8.0",
-                "php": ">=8.1",
-                "psr/http-message": "^1.0 || ^2.0",
-                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
-            },
-            "require-dev": {
-                "andrewsville/php-token-reflection": "^1.4",
-                "aws/aws-php-sns-message-validator": "~1.0",
-                "behat/behat": "~3.0",
-                "composer/composer": "^2.7.8",
-                "dms/phpunit-arraysubset-asserts": "^0.4.0",
-                "doctrine/cache": "~1.4",
-                "ext-dom": "*",
-                "ext-openssl": "*",
-                "ext-sockets": "*",
-                "phpunit/phpunit": "^9.6",
-                "psr/cache": "^2.0 || ^3.0",
-                "psr/simple-cache": "^2.0 || ^3.0",
-                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
-                "yoast/phpunit-polyfills": "^2.0"
-            },
-            "suggest": {
-                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
-                "doctrine/cache": "To use the DoctrineCacheAdapter",
-                "ext-curl": "To send requests using cURL",
-                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
-                "ext-pcntl": "To use client-side monitoring",
-                "ext-sockets": "To use client-side monitoring"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/functions.php"
-                ],
-                "psr-4": {
-                    "Aws\\": "src/"
-                },
-                "exclude-from-classmap": [
-                    "src/data/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Amazon Web Services",
-                    "homepage": "http://aws.amazon.com"
-                }
-            ],
-            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
-            "homepage": "http://aws.amazon.com/sdkforphp",
-            "keywords": [
-                "amazon",
-                "aws",
-                "cloud",
-                "dynamodb",
-                "ec2",
-                "glacier",
-                "s3",
-                "sdk"
-            ],
-            "support": {
-                "forum": "https://github.com/aws/aws-sdk-php/discussions",
-                "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.369.27"
-            },
-            "time": "2026-02-04T19:07:08+00:00"
-        },
         {
             "name": "eluceo/ical",
             "version": "2.16.0",
@@ -280,395 +129,86 @@
             "time": "2025-12-27T19:43:20+00:00"
         },
         {
-            "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "name": "phpmailer/phpmailer",
+            "version": "v7.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "url": "https://github.com/PHPMailer/PHPMailer.git",
+                "reference": "ebf1655bd5b99b3f97e1a3ec0a69e5f4cd7ea088"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/ebf1655bd5b99b3f97e1a3ec0a69e5f4cd7ea088",
+                "reference": "ebf1655bd5b99b3f97e1a3ec0a69e5f4cd7ea088",
                 "shasum": ""
             },
             "require": {
-                "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
-                "php": "^7.2.5 || ^8.0",
-                "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
-            },
-            "provide": {
-                "psr/http-client-implementation": "1.0"
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "php": ">=5.5.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.2",
-                "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
-                "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
-                "psr/log": "^1.1 || ^2.0 || ^3.0"
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "doctrine/annotations": "^1.2.6 || ^1.13.3",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
+                "squizlabs/php_codesniffer": "^3.13.5",
+                "yoast/phpunit-polyfills": "^1.0.4"
             },
             "suggest": {
-                "ext-curl": "Required for CURL handler support",
-                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
-                "psr/log": "Required for using the Log middleware"
+                "decomplexity/SendOauth2": "Adapter for using XOAUTH2 authentication",
+                "directorytree/imapengine": "For uploading sent messages via IMAP, see gmail example",
+                "ext-imap": "Needed to support advanced email address parsing according to RFC822",
+                "ext-mbstring": "Needed to send email in multibyte encoding charset or decode encoded addresses",
+                "ext-openssl": "Needed for secure SMTP sending and DKIM signing",
+                "greew/oauth2-azure-provider": "Needed for Microsoft Azure XOAUTH2 authentication",
+                "hayageek/oauth2-yahoo": "Needed for Yahoo XOAUTH2 authentication",
+                "league/oauth2-google": "Needed for Google XOAUTH2 authentication",
+                "psr/log": "For optional PSR-3 debug logging",
+                "symfony/polyfill-mbstring": "To support UTF-8 if the Mbstring PHP extension is not enabled (^1.2)",
+                "thenetworg/oauth2-azure": "Needed for Microsoft XOAUTH2 authentication"
             },
             "type": "library",
-            "extra": {
-                "bamarni-bin": {
-                    "bin-links": true,
-                    "forward-command": false
-                }
-            },
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
-                    "GuzzleHttp\\": "src/"
+                    "PHPMailer\\PHPMailer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "LGPL-2.1-only"
             ],
             "authors": [
                 {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
+                    "name": "Marcus Bointon",
+                    "email": "phpmailer@synchromedia.co.uk"
                 },
                 {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
+                    "name": "Jim Jagielski",
+                    "email": "jimjag@gmail.com"
                 },
                 {
-                    "name": "Jeremy Lindblom",
-                    "email": "jeremeamia@gmail.com",
-                    "homepage": "https://github.com/jeremeamia"
+                    "name": "Andy Prevost",
+                    "email": "codeworxtech@users.sourceforge.net"
                 },
                 {
-                    "name": "George Mponos",
-                    "email": "gmponos@gmail.com",
-                    "homepage": "https://github.com/gmponos"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
-                },
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com",
-                    "homepage": "https://github.com/sagikazarmark"
-                },
-                {
-                    "name": "Tobias Schultze",
-                    "email": "webmaster@tubo-world.de",
-                    "homepage": "https://github.com/Tobion"
+                    "name": "Brent R. Matzelle"
                 }
             ],
-            "description": "Guzzle is a PHP HTTP client library",
-            "keywords": [
-                "client",
-                "curl",
-                "framework",
-                "http",
-                "http client",
-                "psr-18",
-                "psr-7",
-                "rest",
-                "web service"
-            ],
+            "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
             "support": {
-                "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "issues": "https://github.com/PHPMailer/PHPMailer/issues",
+                "source": "https://github.com/PHPMailer/PHPMailer/tree/v7.0.2"
             },
             "funding": [
                 {
-                    "url": "https://github.com/GrahamCampbell",
+                    "url": "https://github.com/Synchro",
                     "type": "github"
-                },
-                {
-                    "url": "https://github.com/Nyholm",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
-        },
-        {
-            "name": "guzzlehttp/promises",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5 || ^8.0"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
-            },
-            "type": "library",
-            "extra": {
-                "bamarni-bin": {
-                    "bin-links": true,
-                    "forward-command": false
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Promise\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                },
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
-                },
-                {
-                    "name": "Tobias Schultze",
-                    "email": "webmaster@tubo-world.de",
-                    "homepage": "https://github.com/Tobion"
-                }
-            ],
-            "description": "Guzzle promises library",
-            "keywords": [
-                "promise"
-            ],
-            "support": {
-                "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/Nyholm",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-22T14:34:08+00:00"
-        },
-        {
-            "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5 || ^8.0",
-                "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
-            },
-            "provide": {
-                "psr/http-factory-implementation": "1.0",
-                "psr/http-message-implementation": "1.0"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
-            },
-            "suggest": {
-                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
-            },
-            "type": "library",
-            "extra": {
-                "bamarni-bin": {
-                    "bin-links": true,
-                    "forward-command": false
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Psr7\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                },
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "George Mponos",
-                    "email": "gmponos@gmail.com",
-                    "homepage": "https://github.com/gmponos"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
-                },
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com",
-                    "homepage": "https://github.com/sagikazarmark"
-                },
-                {
-                    "name": "Tobias Schultze",
-                    "email": "webmaster@tubo-world.de",
-                    "homepage": "https://github.com/Tobion"
-                },
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com",
-                    "homepage": "https://sagikazarmark.hu"
-                }
-            ],
-            "description": "PSR-7 message implementation that also provides common utility methods",
-            "keywords": [
-                "http",
-                "message",
-                "psr-7",
-                "request",
-                "response",
-                "stream",
-                "uri",
-                "url"
-            ],
-            "support": {
-                "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/Nyholm",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-23T21:21:41+00:00"
-        },
-        {
-            "name": "mtdowling/jmespath.php",
-            "version": "2.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/jmespath/jmespath.php.git",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5 || ^8.0",
-                "symfony/polyfill-mbstring": "^1.17"
-            },
-            "require-dev": {
-                "composer/xdebug-handler": "^3.0.3",
-                "phpunit/phpunit": "^8.5.33"
-            },
-            "bin": [
-                "bin/jp.php"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.8-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/JmesPath.php"
-                ],
-                "psr-4": {
-                    "JmesPath\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                },
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Declaratively specify how to extract elements from a JSON document",
-            "keywords": [
-                "json",
-                "jsonpath"
-            ],
-            "support": {
-                "issues": "https://github.com/jmespath/jmespath.php/issues",
-                "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
-            },
-            "time": "2024-09-04T18:46:31+00:00"
+            "time": "2026-01-09T18:02:33+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -746,210 +286,6 @@
             "time": "2025-12-27T19:41:33+00:00"
         },
         {
-            "name": "psr/http-client",
-            "version": "1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-client.git",
-                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
-                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Client\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP clients",
-            "homepage": "https://github.com/php-fig/http-client",
-            "keywords": [
-                "http",
-                "http-client",
-                "psr",
-                "psr-18"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-client"
-            },
-            "time": "2023-09-23T14:17:50+00:00"
-        },
-        {
-            "name": "psr/http-factory",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
-                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
-            "keywords": [
-                "factory",
-                "http",
-                "message",
-                "psr",
-                "psr-17",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-factory"
-            },
-            "time": "2024-04-15T12:06:14+00:00"
-        },
-        {
-            "name": "psr/http-message",
-            "version": "2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP messages",
-            "homepage": "https://github.com/php-fig/http-message",
-            "keywords": [
-                "http",
-                "http-message",
-                "psr",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-message/tree/2.0"
-            },
-            "time": "2023-04-04T09:54:51+00:00"
-        },
-        {
-            "name": "ralouphie/getallheaders",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ralouphie/getallheaders.git",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "php-coveralls/php-coveralls": "^2.1",
-                "phpunit/phpunit": "^5 || ^6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/getallheaders.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ralph Khattar",
-                    "email": "ralph.khattar@gmail.com"
-                }
-            ],
-            "description": "A polyfill for getallheaders.",
-            "support": {
-                "issues": "https://github.com/ralouphie/getallheaders/issues",
-                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
-            },
-            "time": "2019-03-08T08:55:37+00:00"
-        },
-        {
             "name": "symfony/deprecation-contracts",
             "version": "v3.6.0",
             "source": {
@@ -1015,76 +351,6 @@
                 }
             ],
             "time": "2024-09-25T14:21:43+00:00"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v8.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d937d400b980523dc9ee946bb69972b5e619058d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d937d400b980523dc9ee946bb69972b5e619058d",
-                "reference": "d937d400b980523dc9ee946bb69972b5e619058d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
-            },
-            "require-dev": {
-                "symfony/process": "^7.4|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v8.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-12-01T09:13:36+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3915,6 +3181,76 @@
                 }
             ],
             "time": "2026-01-13T11:36:38+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v8.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "d937d400b980523dc9ee946bb69972b5e619058d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d937d400b980523dc9ee946bb69972b5e619058d",
+                "reference": "d937d400b980523dc9ee946bb69972b5e619058d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-01T09:13:36+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",

--- a/config/config.php
+++ b/config/config.php
@@ -15,11 +15,17 @@ return [
         'path' => getenv('DB_PATH') ?: __DIR__ . '/../database/jaws.db',
     ],
 
-    // AWS SES (Email Service)
+    // SMTP Email Configuration (PHPMailer)
+    'smtp' => [
+        'host' => getenv('SMTP_HOST') ?: 'email-smtp.ca-central-1.amazonaws.com',
+        'port' => (int)(getenv('SMTP_PORT') ?: 587),
+        'secure' => getenv('SMTP_SECURE') ?: 'tls',
+        'username' => getenv('SMTP_USERNAME') ?: '',
+        'password' => getenv('SMTP_PASSWORD') ?: '',
+    ],
+
+    // Email Settings
     'email' => [
-        'region' => getenv('SES_REGION') ?: 'ca-central-1',
-        'smtp_username' => getenv('SES_SMTP_USERNAME') ?: '',
-        'smtp_password' => getenv('SES_SMTP_PASSWORD') ?: '',
         'from_address' => getenv('EMAIL_FROM') ?: 'noreply@nsc-sdc.ca',
         'from_name' => getenv('EMAIL_FROM_NAME') ?: 'Nepean Sailing Club - Social Day Cruising',
         'admin_notification_email' => getenv('ADMIN_NOTIFICATION_EMAIL') ?: 'nsc-sdc@nsc.ca',

--- a/config/container.php
+++ b/config/container.php
@@ -26,7 +26,7 @@ use App\Infrastructure\Persistence\SQLite\CrewRepository;
 use App\Infrastructure\Persistence\SQLite\EventRepository;
 use App\Infrastructure\Persistence\SQLite\SeasonRepository;
 use App\Infrastructure\Persistence\SQLite\UserRepository;
-use App\Infrastructure\Service\AwsSesEmailService;
+use App\Infrastructure\Service\PhpMailerEmailService;
 use App\Infrastructure\Service\ICalendarService;
 use App\Infrastructure\Service\SystemTimeService;
 use App\Infrastructure\Service\JwtTokenService;
@@ -100,7 +100,7 @@ $container->set(UserRepositoryInterface::class, function () {
 
 // Services (External Adapters)
 $container->set(EmailServiceInterface::class, function () {
-    return new AwsSesEmailService();
+    return new PhpMailerEmailService();
 });
 
 $container->set(CalendarServiceInterface::class, function () {

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -22,7 +22,7 @@ Before deploying to production, verify the following:
 - [ ] Code reviewed and approved via Pull Request
 - [ ] Database migrations tested locally
 - [ ] Production `.env` file prepared with secure credentials
-- [ ] AWS SES configured and email sending tested
+- [ ] SMTP credentials configured and email sending tested
 - [ ] Backup of current production database created
 - [ ] Deployment window scheduled (avoid event hours 10:00-18:00)
 - [ ] Rollback plan prepared
@@ -363,10 +363,12 @@ DB_PATH=/opt/bitnami/jaws/database/jaws.db
 JWT_SECRET=your-production-secret-key-at-least-32-characters-long-must-be-different-from-dev
 JWT_EXPIRATION_MINUTES=60
 
-# AWS SES (Email Service)
-SES_REGION=ca-central-1
-SES_SMTP_USERNAME=your_production_smtp_username
-SES_SMTP_PASSWORD=your_production_smtp_password
+# SMTP Email Configuration
+SMTP_HOST=email-smtp.ca-central-1.amazonaws.com
+SMTP_PORT=587
+SMTP_SECURE=tls
+SMTP_USERNAME=your_production_smtp_username
+SMTP_PASSWORD=your_production_smtp_password
 EMAIL_FROM=noreply@nsc-sdc.ca
 EMAIL_FROM_NAME="Nepean Sailing Club - Social Day Cruising"
 
@@ -829,25 +831,31 @@ sudo chmod 775 /opt/bitnami/jaws/database
 #### Issue: Email notifications not sending
 
 **Possible Causes:**
-- AWS SES credentials incorrect
-- Email not verified in AWS SES
-- SES in sandbox mode
+
+- SMTP credentials incorrect
+- SMTP server connection blocked
+- Email address not verified with SMTP provider
 
 **Solution:**
 
-1. Check SES credentials in `.env`:
+1. Check SMTP credentials in `.env`:
    ```bash
-   cat /opt/bitnami/jaws/.env | grep SES
+   cat /opt/bitnami/jaws/.env | grep SMTP
    ```
 
-2. Test sending email via AWS CLI:
+2. Test SMTP connection:
    ```bash
-   aws ses send-email --from noreply@nsc-sdc.ca --to test@example.com --subject "Test" --text "Test"
+   telnet email-smtp.ca-central-1.amazonaws.com 587
    ```
 
-3. Verify email address is verified in AWS SES console
+3. Check PHPMailer debug output in error log:
+   ```bash
+   tail -f /opt/bitnami/apache/logs/error_log | grep -i phpmailer
+   ```
 
-4. Check Apache error log for AWS SES errors
+4. Verify email address is verified with your SMTP provider (e.g., AWS SES)
+
+5. Check Apache error log for SMTP connection errors
 
 #### Issue: Frontend not loading
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -10,7 +10,7 @@ This guide will walk you through setting up JAWS for local development, from ins
 - [Database Initialization](#database-initialization)
 - [Starting the Development Server](#starting-the-development-server)
 - [Verification](#verification)
-- [LocalStack Setup (Optional)](#localstack-setup-optional)
+- [Local Email Testing (Optional)](#local-email-testing-optional)
 - [Frontend Integration](#frontend-integration)
 - [Common Setup Issues](#common-setup-issues)
 - [Next Steps](#next-steps)
@@ -84,7 +84,7 @@ php -m
 - **Postman** - API testing tool
   - Download: https://www.postman.com/downloads/
 
-- **Docker Desktop** - Required only for LocalStack (AWS SES emulation)
+- **Docker Desktop** - Optional for local SMTP testing (MailHog)
   - Download: https://www.docker.com/products/docker-desktop
 
 ---
@@ -107,7 +107,8 @@ composer install
 ```
 
 This will install:
-- `phpmailer/phpmailer` - Email service via AWS SES
+
+- `phpmailer/phpmailer` - Email service via SMTP
 - `eluceo/ical` - iCalendar file generation
 - `phpunit/phpunit` (dev) - Testing framework
 - `robmorgan/phinx` (dev) - Database migrations
@@ -155,12 +156,14 @@ DB_PATH=database/jaws.db
 JWT_SECRET=your-secret-key-at-least-32-characters-long-change-this-in-production
 JWT_EXPIRATION_MINUTES=60
 
-# AWS SES (Email Service)
-# For development, you can use LocalStack (see LocalStack Setup section)
-SES_REGION=ca-central-1
-SES_SMTP_USERNAME=your_smtp_username
-SES_SMTP_PASSWORD=your_smtp_password
-# SES_ENDPOINT=http://localhost:4566  # Uncomment for LocalStack
+# SMTP Email Configuration
+# For production: Use AWS SES SMTP endpoint
+# For development: Use MailHog or similar (localhost:1025)
+SMTP_HOST=email-smtp.ca-central-1.amazonaws.com
+SMTP_PORT=587
+SMTP_SECURE=tls
+SMTP_USERNAME=your_smtp_username
+SMTP_PASSWORD=your_smtp_password
 EMAIL_FROM=noreply@nsc-sdc.ca
 EMAIL_FROM_NAME="Nepean Sailing Club - Social Day Cruising"
 
@@ -331,9 +334,9 @@ You should see the JAWS frontend application (or a placeholder if the frontend h
 
 ---
 
-## LocalStack Setup (Optional)
+## Local Email Testing (Optional)
 
-LocalStack emulates AWS services locally, allowing you to test email functionality without using real AWS SES or incurring costs.
+For local development, use MailHog to capture and view emails without sending real messages.
 
 ### Quick Start
 

--- a/src/Infrastructure/Service/PhpMailerEmailService.php
+++ b/src/Infrastructure/Service/PhpMailerEmailService.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Service;
+
+use App\Application\Port\Service\EmailServiceInterface;
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception as PHPMailerException;
+
+/**
+ * PHPMailer Email Service
+ *
+ * Implements email sending via SMTP using PHPMailer.
+ * Supports AWS SES SMTP endpoints and other SMTP servers.
+ */
+class PhpMailerEmailService implements EmailServiceInterface
+{
+    private string $smtpHost;
+    private int $smtpPort;
+    private string $smtpUsername;
+    private string $smtpPassword;
+    private string $smtpSecure;
+    private string $defaultFromEmail;
+    private string $defaultFromName;
+    private bool $debug;
+
+    public function __construct(
+        ?string $smtpHost = null,
+        ?int $smtpPort = null,
+        ?string $smtpUsername = null,
+        ?string $smtpPassword = null,
+        ?string $smtpSecure = null,
+        ?string $defaultFromEmail = null,
+        ?string $defaultFromName = null,
+        ?bool $debug = null
+    ) {
+        // Use environment variables if parameters not provided
+        $this->smtpHost = $smtpHost
+            ?? getenv('SMTP_HOST') ?: 'email-smtp.ca-central-1.amazonaws.com';
+        $this->smtpPort = $smtpPort
+            ?? (int)(getenv('SMTP_PORT') ?: 587);
+        $this->smtpUsername = $smtpUsername
+            ?? getenv('SMTP_USERNAME') ?: '';
+        $this->smtpPassword = $smtpPassword
+            ?? getenv('SMTP_PASSWORD') ?: '';
+        $this->smtpSecure = $smtpSecure
+            ?? getenv('SMTP_SECURE') ?: PHPMailer::ENCRYPTION_STARTTLS;
+        $this->defaultFromEmail = $defaultFromEmail
+            ?? getenv('EMAIL_FROM') ?: 'noreply@example.com';
+        $this->defaultFromName = $defaultFromName
+            ?? getenv('EMAIL_FROM_NAME') ?: 'JAWS System';
+        $this->debug = $debug
+            ?? (getenv('APP_DEBUG') === 'true');
+    }
+
+    public function send(
+        string $to,
+        string $subject,
+        string $body,
+        ?string $fromName = null,
+        ?string $fromEmail = null
+    ): bool {
+        try {
+            $mail = $this->createMailer();
+
+            // Set sender
+            $mail->setFrom(
+                $fromEmail ?? $this->defaultFromEmail,
+                $fromName ?? $this->defaultFromName
+            );
+
+            // Set recipient
+            $mail->addAddress($to);
+
+            // Set email content
+            $mail->Subject = $subject;
+            $mail->Body = $body;
+            $mail->isHTML(true);  // Support HTML email bodies
+
+            // Send email
+            $result = $mail->send();
+
+            if ($result) {
+                error_log("Email sent successfully to: {$to}");
+                return true;
+            }
+
+            error_log("Email send failed to: {$to} - No result returned");
+            return false;
+
+        } catch (PHPMailerException $e) {
+            error_log("Email send failed to: {$to} - PHPMailer Error: " . $e->getMessage());
+            return false;
+        } catch (\Exception $e) {
+            error_log("Email send failed to: {$to} - General Error: " . $e->getMessage());
+            return false;
+        }
+    }
+
+    public function sendBulk(
+        array $recipients,
+        string $subject,
+        string $body,
+        ?string $fromName = null,
+        ?string $fromEmail = null
+    ): array {
+        $results = [];
+
+        foreach ($recipients as $recipient) {
+            $results[$recipient] = $this->send($recipient, $subject, $body, $fromName, $fromEmail);
+        }
+
+        return $results;
+    }
+
+    public function validateEmail(string $email): bool
+    {
+        return filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+    }
+
+    /**
+     * Create configured PHPMailer instance
+     *
+     * @return PHPMailer
+     * @throws PHPMailerException
+     */
+    private function createMailer(): PHPMailer
+    {
+        $mail = new PHPMailer(true);  // Enable exceptions
+
+        // SMTP configuration (based on working test script from issue #37)
+        $mail->isSMTP();
+        $mail->Host = $this->smtpHost;
+        $mail->Port = $this->smtpPort;
+        $mail->SMTPAuth = true;
+        $mail->Username = $this->smtpUsername;
+        $mail->Password = $this->smtpPassword;
+        $mail->SMTPSecure = $this->smtpSecure;
+
+        // Character encoding
+        $mail->CharSet = PHPMailer::CHARSET_UTF8;
+
+        // Debug mode (only in development)
+        if ($this->debug) {
+            $mail->SMTPDebug = 2;  // Enable verbose debug output
+            $mail->Debugoutput = function($str, $level) {
+                error_log("PHPMailer Debug: {$str}");
+            };
+        } else {
+            $mail->SMTPDebug = 0;  // Disable debug output in production
+        }
+
+        // Timeout settings
+        $mail->Timeout = 30;  // Connection timeout (seconds)
+
+        // Disable SSL verification for local development (localhost)
+        if (getenv('APP_ENV') === 'development' && strpos($this->smtpHost, 'localhost') !== false) {
+            $mail->SMTPOptions = [
+                'ssl' => [
+                    'verify_peer' => false,
+                    'verify_peer_name' => false,
+                    'allow_self_signed' => true
+                ]
+            ];
+        }
+
+        return $mail;
+    }
+}


### PR DESCRIPTION
Replace AWS SDK email implementation with PHPMailer using SMTP to resolve production email sending failures. The previous implementation required IAM credentials, but production environment only has SMTP credentials configured.

Changes:
- Remove aws/aws-sdk-php dependency, add phpmailer/phpmailer ^7.0
- Create `PhpMailerEmailService` implementing `EmailServiceInterface`
- Update `container.php` to use `PhpMailerEmailService`
- Replace SES_* environment variables with SMTP_* variables
- Update `config.php` with new smtp configuration section
- Update all documentation (CLAUDE.md, README.md, SETUP.md, DEPLOYMENT.md)

SMTP configuration uses same interface contract, so no changes required to use cases, controllers, or tests. All 666 unit/integration tests pass.

Addresses #5.