### PR TITLE
fix: distribute crews to boats by capacity instead of round-robin

### DIFF
--- a/src/Application/UseCase/Season/ProcessSeasonUpdateUseCase.php
+++ b/src/Application/UseCase/Season/ProcessSeasonUpdateUseCase.php
@@ -200,15 +200,19 @@ class ProcessSeasonUpdateUseCase
             ];
         }
 
-        // Distribute selected crews to boats (initial even distribution before optimization)
+        // Distribute selected crews to boats based on each boat's occupied_berths
+        // This respects the capacity-aware distribution calculated by SelectionService
         $crewIndex = 0;
-        foreach ($selectedCrews as $crew) {
-            if (count($crewedBoats) > 0) {
-                $boatIndex = $crewIndex % count($crewedBoats);
-                $crewedBoats[$boatIndex]['crews'][] = $crew;
+        foreach ($crewedBoats as &$crewedBoat) {
+            $boat = $crewedBoat['boat'];
+            $crewsForThisBoat = $boat->occupied_berths;
+
+            for ($i = 0; $i < $crewsForThisBoat && $crewIndex < count($selectedCrews); $i++) {
+                $crewedBoat['crews'][] = $selectedCrews[$crewIndex];
                 $crewIndex++;
             }
         }
+        unset($crewedBoat); // Break the reference
 
         return [
             'event_id' => $eventId->toString(),


### PR DESCRIPTION
The `consolidateEvent()` method was distributing crews evenly across boats using round-robin, ignoring the `occupied_berths` value calculated by `SelectionService.` This meant larger boats didn't get proportionally more crews despite having higher capacity.

Now respects each boat's occupied_berths (calculated by SelectionService's capacity-matching algorithm) to distribute crews appropriately - larger boats get more crews matching their max_berths allocation.

Added comprehensive integration tests:
- `testCrewsDistributedAccordingToOccupiedBerths`: validates 2-boat scenario
- `testUnevenCapacityDistributionRespectsBerthsPerBoat`: validates 3-boat scenario

Addresses #17 