### PR TITLE
feat: add All Boats option to crew whitelist dropdown 

### DIFF
--- a/public/app/admin-user-edit.html
+++ b/public/app/admin-user-edit.html
@@ -113,7 +113,7 @@
             <div id="section-partner" class="form-section" style="display:none;">
                 <h2>Partner Assignment</h2>
                 <div class="field-group">
-                    <label for="partner-select">Preferred Sailing Partner</label>
+                    <label for="partner-select">Partner</label>
                     <select id="partner-select" class="form-control">
                         <option value="">None</option>
                     </select>
@@ -124,7 +124,7 @@
             <!-- Whitelist Management (crew only) -->
             <div id="section-whitelist" class="form-section" style="display:none;">
                 <h2>Boat Whitelist</h2>
-                <p class="help-text">Boats this crew member has expressed a preference for.</p>
+                <p class="help-text">Preferred assignments</p>
 
                 <div id="whitelist-table-container">
                     <p class="text-muted">No boats whitelisted.</p>

--- a/public/app/js/pages/admin-user-edit-page.js
+++ b/public/app/js/pages/admin-user-edit-page.js
@@ -293,6 +293,14 @@ function refreshWhitelistAddDropdown(crew) {
     }
 
     const available = allBoats.filter(b => !whitelist.includes(b.key));
+
+    if (available.length > 1) {
+        const allOpt = document.createElement('option');
+        allOpt.value = '__all__';
+        allOpt.textContent = 'All Boats';
+        select.appendChild(allOpt);
+    }
+
     available.forEach(boat => {
         const opt = document.createElement('option');
         opt.value = boat.key;
@@ -318,11 +326,24 @@ async function handleWhitelistAdd() {
     btn.disabled = true;
 
     try {
-        const updated = await adminService.addToCrewWhitelist(targetUserData.crew.key, boatKey);
-        targetUserData.crew = updated;
-        refreshWhitelistTable(updated);
-        refreshWhitelistAddDropdown(updated);
-        showToast('Boat added to whitelist.', 'success');
+        if (boatKey === '__all__') {
+            const whitelist = targetUserData.crew.whitelist || [];
+            const available = allBoats.filter(b => !whitelist.includes(b.key));
+            let updated = targetUserData.crew;
+            for (const boat of available) {
+                updated = await adminService.addToCrewWhitelist(targetUserData.crew.key, boat.key);
+            }
+            targetUserData.crew = updated;
+            refreshWhitelistTable(updated);
+            refreshWhitelistAddDropdown(updated);
+            showToast(`All boats added to whitelist.`, 'success');
+        } else {
+            const updated = await adminService.addToCrewWhitelist(targetUserData.crew.key, boatKey);
+            targetUserData.crew = updated;
+            refreshWhitelistTable(updated);
+            refreshWhitelistAddDropdown(updated);
+            showToast('Boat added to whitelist.', 'success');
+        }
     } catch (error) {
         console.error('Failed to add to whitelist:', error);
         showToast(error.message || 'Failed to add boat to whitelist', 'error');


### PR DESCRIPTION
Adds an "All Boats" option at the top of the whitelist add dropdown
when more than one boat is available. Selecting it adds every
non-whitelisted boat in a single click.

Also shortens the partner label and whitelist help text.

Closes #32 