### PR TITLE
test: enable the skipped API tests

### DIFF
--- a/src/Application/UseCase/User/AddProfileUseCase.php
+++ b/src/Application/UseCase/User/AddProfileUseCase.php
@@ -110,9 +110,7 @@ class AddProfileUseCase
         $rank = $this->rankingService->calculateCrewRank($crew, []);
 
         // Set rank
-        foreach ($rank->toArray() as $dimension => $value) {
-            $crew->setRankDimension($dimension, $value);
-        }
+        $crew->setRank($rank);
 
         // Link to user
         $crew->setUserId($userId);
@@ -170,9 +168,7 @@ class AddProfileUseCase
         $rank = $this->rankingService->calculateBoatRank($boat, []);
 
         // Set rank
-        foreach ($rank->toArray() as $dimension => $value) {
-            $boat->setRankDimension($dimension, $value);
-        }
+        $boat->setRank($rank);
 
         // Link to user
         $boat->setOwnerUserId($userId);

--- a/tests/Integration/Api/UserProfileApiTest.php
+++ b/tests/Integration/Api/UserProfileApiTest.php
@@ -259,26 +259,20 @@ class UserProfileApiTest extends TestCase
 
         // Boat owner adds crew profile (becomes flex)
         $response = $this->makeRequest('POST', "{$this->baseUrl}/users/me", [
+            'profileType' => 'crew',
             'crewProfile' => [
                 'firstName' => "Flex{$suffix}",
                 'lastName' => "Crew",
                 'displayName' => "Flex Crew {$suffix}",
                 'skill' => 1,
                 'mobile' => '555-1111',
+                'socialPreference' => false,
             ],
         ], [
             "Authorization: Bearer {$testData['token']}",
         ]);
 
-        // May return 200, 201, 400 (not implemented), or 404 (endpoint not found)
-        $this->assertContains($response['status'], [200, 201, 400, 404]);
-
-        // Skip verification if endpoint doesn't exist
-        if ($response['status'] === 404 || $response['status'] === 400) {
-            $this->markTestSkipped('POST /api/users/me endpoint may not be implemented');
-            $this->cleanupTestUser($testData['userId']);
-            return;
-        }
+        $this->assertEquals(201, $response['status']);
 
         $this->assertTrue($response['body']['success']);
 
@@ -305,6 +299,7 @@ class UserProfileApiTest extends TestCase
 
         // Crew adds boat profile (becomes flex)
         $response = $this->makeRequest('POST', "{$this->baseUrl}/users/me", [
+            'profileType' => 'boat',
             'boatProfile' => [
                 'ownerFirstName' => "Flex{$suffix}",
                 'ownerLastName' => "Boat",
@@ -313,20 +308,13 @@ class UserProfileApiTest extends TestCase
                 'minBerths' => 2,
                 'maxBerths' => 4,
                 'assistanceRequired' => false,
+                'socialPreference' => false,
             ],
         ], [
             "Authorization: Bearer {$testData['token']}",
         ]);
 
-        // May return 200, 201, 400 (not implemented), or 404 (endpoint not found)
-        $this->assertContains($response['status'], [200, 201, 400, 404]);
-
-        // Skip verification if endpoint doesn't exist
-        if ($response['status'] === 404 || $response['status'] === 400) {
-            $this->markTestSkipped('POST /api/users/me endpoint may not be implemented');
-            $this->cleanupTestUser($testData['userId']);
-            return;
-        }
+        $this->assertEquals(201, $response['status']);
 
         $this->assertTrue($response['body']['success']);
 


### PR DESCRIPTION
- replace per-dimension rank setting with direct Rank assignment for crew and boat to avoid runtime type errors
- update user profile API integration tests to require implemented POST /api/users/me behaviour (no 400/404 skip fallback)
- send required add-profile fields (`profileType`, `socialPreference`) and assert `201` responses for added profiles