### PR TITLE
fix: correct field name mismatch preventing edit profile saves

### DIFF
--- a/public/app/js/pages/edit-profile-page.js
+++ b/public/app/js/pages/edit-profile-page.js
@@ -233,6 +233,11 @@ document.getElementById('edit-profile-form').addEventListener('submit', async fu
         console.log('Password change requested - backend will verify current password');
     }
 
+    const saveButton = e.target.querySelector('[type="submit"]');
+    const originalLabel = saveButton.textContent;
+    saveButton.disabled = true;
+    saveButton.textContent = 'Saving...';
+
     // Build profile update object
     let profileUpdates = {};
 
@@ -242,18 +247,18 @@ document.getElementById('edit-profile-form').addEventListener('submit', async fu
             lastName: document.getElementById('last_name').value,
             membershipNumber: document.getElementById('membership_number').value,
             experience: document.getElementById('experience').value,
-            whatsappGroup: document.getElementById('whatsapp_group').checked
+            socialPreference: document.getElementById('whatsapp_group').checked
         };
     } else {
         profileUpdates = {
-            firstName: document.getElementById('first_name').value,
-            lastName: document.getElementById('last_name').value,
-            phone: document.getElementById('phone').value,
-            boatName: document.getElementById('boat_name').value,
-            minCrew: document.getElementById('min_crew').value,
-            maxCrew: document.getElementById('max_crew').value,
-            requestFirstMate: document.getElementById('request_first_mate').checked,
-            whatsappGroup: document.getElementById('whatsapp_group').checked
+            ownerFirstName: document.getElementById('first_name').value,
+            ownerLastName: document.getElementById('last_name').value,
+            ownerMobile: document.getElementById('phone').value,
+            displayName: document.getElementById('boat_name').value,
+            minBerths: document.getElementById('min_crew').value,
+            maxBerths: document.getElementById('max_crew').value,
+            assistanceRequired: document.getElementById('request_first_mate').checked,
+            socialPreference: document.getElementById('whatsapp_group').checked
         };
     }
 
@@ -282,6 +287,8 @@ document.getElementById('edit-profile-form').addEventListener('submit', async fu
             window.location.href = 'dashboard.html';
         }, 3200);
     } else {
+        saveButton.disabled = false;
+        saveButton.textContent = originalLabel;
         showError(result.error || 'Failed to update profile');
     }
 });

--- a/src/Application/UseCase/User/UpdateUserProfileUseCase.php
+++ b/src/Application/UseCase/User/UpdateUserProfileUseCase.php
@@ -111,6 +111,12 @@ class UpdateUserProfileUseCase
         $originalRank = $crew->getRank();
 
         // Update allowed fields
+        if (isset($profile['firstName'])) {
+            $crew->setFirstName($profile['firstName']);
+        }
+        if (isset($profile['lastName'])) {
+            $crew->setLastName($profile['lastName']);
+        }
         if (isset($profile['displayName'])) {
             $crew->setDisplayName($profile['displayName']);
         }
@@ -154,6 +160,12 @@ class UpdateUserProfileUseCase
         $originalRank = $boat->getRank();
 
         // Update allowed fields
+        if (isset($profile['ownerFirstName'])) {
+            $boat->setOwnerFirstName($profile['ownerFirstName']);
+        }
+        if (isset($profile['ownerLastName'])) {
+            $boat->setOwnerLastName($profile['ownerLastName']);
+        }
         if (isset($profile['displayName'])) {
             $boat->setDisplayName($profile['displayName']);
         }


### PR DESCRIPTION
The "About You" section on the Edit Profile page was silently failing to persist any changes. The frontend was submitting field names that didn't match what the backend's isset() checks expected, so the boat/ crew entities were never mutated and the repository saved unchanged data.

Frontend (edit-profile-page.js):
- Boat owner: renamed all keys to backend names (phone→ownerMobile, boatName→displayName, minCrew→minBerths, maxCrew→maxBerths, requestFirstMate→assistanceRequired, whatsappGroup→socialPreference,
  firstName/lastName→ownerFirstName/ownerLastName)
- Crew: renamed whatsappGroup→socialPreference

Backend (UpdateUserProfileUseCase.php):
- updateBoatProfile: added handling for ownerFirstName/ownerLastName
- updateCrewProfile: added handling for firstName/lastName

Also adds "Saving..." disabled state to the Save Changes button while the API call is in flight, matching the dashboard page behaviour.

Fixes #38.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>