### PR TITLE
fix: clear stale GUARANTEED status and correct commitment rank for dropped crews

### DIFF
--- a/src/Application/UseCase/Season/ProcessSeasonUpdateUseCase.php
+++ b/src/Application/UseCase/Season/ProcessSeasonUpdateUseCase.php
@@ -90,6 +90,16 @@ class ProcessSeasonUpdateUseCase
                 $selectionResult['waitlisted_crews']
             );
 
+            // Reset stale GUARANTEED statuses before commitment rank calculation.
+            // Crews dropped from selection (e.g., due to reduced berths) must have
+            // their GUARANTEED status cleared so the ranking algorithm treats them
+            // as normal AVAILABLE crew, not as currently-assigned crew.
+            $selectedCrewKeyStrings = array_map(
+                fn(Crew $crew) => $crew->getKey()->toString(),
+                $selectionResult['selected_crews']
+            );
+            $this->resetStaleGuaranteed($squad, $eventId, $selectedCrewKeyStrings);
+
             // Phase 3: Assignment optimization (next event only)
             if ($eventIdString === $nextEventId) {
                 $flotilla = $this->runAssignment($flotilla);
@@ -325,6 +335,38 @@ class ProcessSeasonUpdateUseCase
             'waitlist_boats' => $serializedWaitlistBoats,
             'waitlist_crews' => $serializedWaitlistCrews,
         ];
+    }
+
+    /**
+     * Reset stale GUARANTEED availability statuses for crews no longer selected
+     *
+     * After selection runs, any crew who carried GUARANTEED status from a previous
+     * pipeline run but is NOT in the current selection result must be reset to
+     * AVAILABLE. Without this, dropped crews keep GUARANTEED in the database,
+     * which causes the commitment rank calculation to unfairly prioritise them.
+     *
+     * @param Squad $squad All crew
+     * @param EventId $eventId Event being processed
+     * @param array<string> $selectedCrewKeys Crew keys in the current selection result
+     */
+    private function resetStaleGuaranteed(
+        Squad $squad,
+        EventId $eventId,
+        array $selectedCrewKeys
+    ): void {
+        foreach ($squad->all() as $crew) {
+            if (
+                !in_array($crew->getKey()->toString(), $selectedCrewKeys, true)
+                && $crew->getAvailability($eventId) === AvailabilityStatus::GUARANTEED
+            ) {
+                $crew->setAvailability($eventId, AvailabilityStatus::AVAILABLE);
+                $this->crewRepository->updateAvailability(
+                    $crew->getKey(),
+                    $eventId,
+                    AvailabilityStatus::AVAILABLE
+                );
+            }
+        }
     }
 
     /**

--- a/src/Domain/Service/RankingService.php
+++ b/src/Domain/Service/RankingService.php
@@ -184,10 +184,12 @@ class RankingService
 
             // Map availability to commitment rank
             // Higher value = higher priority (SelectionService sorts descending)
+            // Note: GUARANTEED here means stale from a previous run (crew is NOT in
+            // $assignedCrewKeys), so it should rank the same as AVAILABLE (rank=2).
             $availability = $crew->getAvailability($nextEventId);
             $commitmentRank = match ($availability) {
-                AvailabilityStatus::GUARANTEED => 3,    // Currently assigned for this event
-                AvailabilityStatus::AVAILABLE => 2,     // Normal priority
+                AvailabilityStatus::GUARANTEED,
+                AvailabilityStatus::AVAILABLE => 2,     // Normal priority (stale GUARANTEED = AVAILABLE)
                 default => 0,                           // UNAVAILABLE or WITHDRAWN
             };
 

--- a/tests/Unit/Domain/Service/RankingServiceTest.php
+++ b/tests/Unit/Domain/Service/RankingServiceTest.php
@@ -176,7 +176,9 @@ class RankingServiceTest extends TestCase
         $this->assertEquals(1, $crew2->getRank()->getDimension(CrewRankDimension::ABSENCE));
     }
 
-    // Tests that crew with guaranteed availability receives commitment rank of 3 (high priority)
+    // Tests that stale GUARANTEED (not in assignedCrewKeys) receives commitment rank of 2 (normal priority)
+    // Stale GUARANTEED arises when crew was assigned in a prior run but has since been dropped from
+    // selection (e.g. berths reduced). They should rank the same as AVAILABLE, not as truly-assigned crew.
     public function testUpdateCrewCommitmentRanksWithGuaranteed(): void
     {
         // Arrange
@@ -184,11 +186,11 @@ class RankingServiceTest extends TestCase
         $eventId = EventId::fromString('Fri May 29');
         $crew->setAvailability($eventId, AvailabilityStatus::GUARANTEED);
 
-        // Act
+        // Act — crew is NOT in assignedCrewKeys (stale GUARANTEED)
         $this->service->updateCrewCommitmentRanks([$crew], $eventId);
 
-        // Assert
-        $this->assertEquals(3, $crew->getRank()->getDimension(CrewRankDimension::COMMITMENT));
+        // Assert — stale GUARANTEED treated as AVAILABLE (rank=2), not as assigned (rank=3)
+        $this->assertEquals(2, $crew->getRank()->getDimension(CrewRankDimension::COMMITMENT));
     }
 
     // Tests that crew with available status receives commitment rank of 2 (normal priority)
@@ -236,7 +238,7 @@ class RankingServiceTest extends TestCase
         $this->assertEquals(0, $crew->getRank()->getDimension(CrewRankDimension::COMMITMENT));
     }
 
-    // Tests commitment ranking calculation across multiple crews with different availability
+    // Tests commitment ranking across multiple crews: stale GUARANTEED → 2, UNAVAILABLE → 0
     public function testUpdateCrewCommitmentRanksWithMultipleCrews(): void
     {
         // Arrange
@@ -247,11 +249,11 @@ class RankingServiceTest extends TestCase
         $crew1->setAvailability($eventId, AvailabilityStatus::GUARANTEED);
         $crew2->setAvailability($eventId, AvailabilityStatus::UNAVAILABLE);
 
-        // Act
+        // Act — neither crew is in assignedCrewKeys
         $this->service->updateCrewCommitmentRanks([$crew1, $crew2], $eventId);
 
-        // Assert
-        $this->assertEquals(3, $crew1->getRank()->getDimension(CrewRankDimension::COMMITMENT));
+        // Assert — stale GUARANTEED ranks same as AVAILABLE (rank=2); UNAVAILABLE → 0
+        $this->assertEquals(2, $crew1->getRank()->getDimension(CrewRankDimension::COMMITMENT));
         $this->assertEquals(0, $crew2->getRank()->getDimension(CrewRankDimension::COMMITMENT));
     }
 


### PR DESCRIPTION
Two bugs caused crew dropped from selection (e.g. after berths reduced) to retain stale GUARANTEED status and receive an inflated commitment rank of 3 on subsequent pipeline runs, unfairly re-prioritizing them over other crew.

Fix A (`ProcessSeasonUpdateUseCase`): add `resetStaleGuaranteed()` called after every selection phase. Any crew not in the current selection result whose crew_availability.status is GUARANTEED is immediately reset to AVAILABLE in both memory and the database, keeping crew_availability consistent with the flotilla across all future events.

Fix B (`RankingService`): crew reaching the GUARANTEED branch of `updateCrewCommitmentRanks()` is by definition not in `$assignedCrewKeys`, so their status is stale. Map GUARANTEED to rank=2 (same as AVAILABLE) rather than 3, matching the semantics of the code path.

Updated two unit tests that previously asserted the buggy rank=3 value for stale GUARANTEED crew.

Addresses #40 