### PR TITLE
refactor(email): support MailHog SMTP without auth or encryption

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -166,6 +166,16 @@ SMTP_PASSWORD=your_smtp_password
 EMAIL_FROM=noreply@nsc-sdc.ca
 EMAIL_FROM_NAME="Nepean Sailing Club - Social Day Cruising"
 
+# Alternative: MailHog (local SMTP testing, no auth or encryption needed)
+# SMTP_HOST=localhost
+# SMTP_PORT=1025
+# SMTP_SECURE=
+# SMTP_USERNAME=
+# SMTP_PASSWORD=
+# EMAIL_FROM=system@example.com
+# EMAIL_FROM_NAME="JAWS System (local)"
+# APP_ENV=local
+
 # Application
 APP_DEBUG=true
 APP_ENV=development

--- a/src/Infrastructure/Service/PhpMailerEmailService.php
+++ b/src/Infrastructure/Service/PhpMailerEmailService.php
@@ -44,8 +44,9 @@ class PhpMailerEmailService implements EmailServiceInterface
             ?? getenv('SMTP_USERNAME') ?: '';
         $this->smtpPassword = $smtpPassword
             ?? getenv('SMTP_PASSWORD') ?: '';
+        $smtpSecureEnv = getenv('SMTP_SECURE');
         $this->smtpSecure = $smtpSecure
-            ?? getenv('SMTP_SECURE') ?: PHPMailer::ENCRYPTION_STARTTLS;
+            ?? ($smtpSecureEnv !== false ? $smtpSecureEnv : PHPMailer::ENCRYPTION_STARTTLS);
         $this->defaultFromEmail = $defaultFromEmail
             ?? getenv('EMAIL_FROM') ?: 'noreply@example.com';
         $this->defaultFromName = $defaultFromName
@@ -133,7 +134,7 @@ class PhpMailerEmailService implements EmailServiceInterface
         $mail->isSMTP();
         $mail->Host = $this->smtpHost;
         $mail->Port = $this->smtpPort;
-        $mail->SMTPAuth = true;
+        $mail->SMTPAuth = $this->smtpUsername !== '';
         $mail->Username = $this->smtpUsername;
         $mail->Password = $this->smtpPassword;
         $mail->SMTPSecure = $this->smtpSecure;
@@ -155,7 +156,8 @@ class PhpMailerEmailService implements EmailServiceInterface
         $mail->Timeout = 30;  // Connection timeout (seconds)
 
         // Disable SSL verification for local development (localhost)
-        if (getenv('APP_ENV') === 'development' && strpos($this->smtpHost, 'localhost') !== false) {
+        $appEnv = getenv('APP_ENV') ?: '';
+        if (in_array($appEnv, ['development', 'local']) && strpos($this->smtpHost, 'localhost') !== false) {
             $mail->SMTPOptions = [
                 'ssl' => [
                     'verify_peer' => false,


### PR DESCRIPTION
Since LocalStack was removed in https://github.com/t3moses/JAWS/pull/12 we can now use a simpler solution such as [MailHog ](https://github.com/mailhog/MailHog)to capture and view e-mails in a testing environment.  It does require a slight tweak to the `PhpMailerEmailService` to disable TLS when the environment is "Development" or "Local".   The production environment will continue to send e-mail via AWS.

All that is required is this configuration in the `.env` file for development machines:
```text
# SMTP Configuration (MailHog for local testing)
SMTP_HOST=localhost
SMTP_PORT=1025
SMTP_SECURE=
SMTP_USERNAME=
SMTP_PASSWORD=
```
Below are some screenshots of what MailHog looks like (it has a web interface that shows the captured e-mails).

<img width="1133" height="852" alt="image" src="https://github.com/user-attachments/assets/ce7f1eb3-f185-4e12-bd5a-cf06a77299d3" />

<img width="1133" height="852" alt="image" src="https://github.com/user-attachments/assets/ce65fa93-2f6e-4cd2-8a8b-0fe834698ff2" />

Changes in this PR:

- respect empty `SMTP_SECURE` instead of forcing STARTTLS
- set `SMTPAuth` only when `SMTP_USERNAME` is configured
- treat `APP_ENV=local` like development for localhost SMTP options
- document MailHog config example in setup guide