### PR TITLE
fix(web): remove 'How do I update my info' from FAQ

### DIFF
--- a/public/app/faq.html
+++ b/public/app/faq.html
@@ -65,11 +65,6 @@
             </div>
 
             <div class="faq-item">
-                <h3>How do I update my info?</h3>
-                <p>Right now, you can't edit directly. Just hit up the admin to delete your account, then register again with your new details. Easy peasy!</p>
-            </div>
-
-            <div class="faq-item">
                 <h3>Why did I get a random AWS email?</h3>
                 <p>That's just email verification! It's optional but recommended—it'll let us send you reminders and cool notifications in the future. The admin kicks off this process.</p>
             </div>


### PR DESCRIPTION
Removes the "How do I update my info?" section from FAQ that is no longer relevant.

Closes #41