### PR TITLE
feat: add mobile field for WhatsApp opt-in and loading states on form buttons

### DIFF
--- a/public/app/account_boat.html
+++ b/public/app/account_boat.html
@@ -80,7 +80,7 @@
                     <div class="form-group">
                         <label for="phone">Phone Number *</label>
                         <input type="tel" id="phone" name="phone" required placeholder="(555) 123-4567">
-                        <small>For weather-related morning calls from the coordinator.</small>
+                        <small>For weather-related morning calls and the WhatsApp group (if you join).</small>
                     </div>
 
                     <div class="form-group">
@@ -143,7 +143,7 @@
                     <div class="form-group">
                         <label style="display: flex; align-items: flex-start; cursor: pointer;">
                             <input type="checkbox" id="whatsapp_group" name="whatsapp_group" style="width: auto; margin-right: 0.75rem; margin-top: 0.25rem;">
-                            <span>I would like to join the program's WhatsApp group</span>
+                            <span>I would like to join the program's WhatsApp group (we'll use your phone number above)</span>
                         </label>
                     </div>
 

--- a/public/app/account_crew.html
+++ b/public/app/account_crew.html
@@ -119,6 +119,12 @@
                         <small>Stay connected with other sailors and get event updates!</small>
                     </div>
 
+                    <div class="form-group" id="mobile-group" style="display: none;">
+                        <label for="mobile">Mobile Number *</label>
+                        <input type="tel" id="mobile" name="mobile" placeholder="(555) 123-4567">
+                        <small>Required to add you to the WhatsApp group.</small>
+                    </div>
+
                     <div style="text-align: center; margin-top: 3rem;">
                         <button type="submit" class="btn btn-primary">Complete Registration</button>
                     </div>

--- a/public/app/js/authService.js
+++ b/public/app/js/authService.js
@@ -112,7 +112,8 @@ function transformProfile(profileData, accountType) {
             lastName: profileData.lastName || '',
             membershipNumber: profileData.membershipNumber || '',
             experience: profileData.experience,
-            whatsappGroup: profileData.socialPreference || false
+            whatsappGroup: profileData.socialPreference || false,
+            mobile: profileData.mobile || ''
         };
     } else {
         // Boat owner profile - map from backend BoatResponse fields

--- a/public/app/js/pages/account-boat-page.js
+++ b/public/app/js/pages/account-boat-page.js
@@ -14,12 +14,19 @@ if (await isSignedIn()) {
 document.querySelector('form').addEventListener('submit', async function(e) {
     e.preventDefault();
 
+    const submitButton = this.querySelector('[type="submit"]');
+    const originalLabel = submitButton.textContent;
+    submitButton.disabled = true;
+    submitButton.textContent = 'Creating account...';
+
     // Get password values
     const password = document.getElementById('password').value;
     const confirmPassword = document.getElementById('confirm_password').value;
 
     // Validate passwords match
     if (password !== confirmPassword) {
+        submitButton.disabled = false;
+        submitButton.textContent = originalLabel;
         alert('Passwords do not match! Please try again.');
         return;
     }
@@ -27,6 +34,8 @@ document.querySelector('form').addEventListener('submit', async function(e) {
     // Validate password requirements
     const validation = validatePassword(password);
     if (!validation.isValid) {
+        submitButton.disabled = false;
+        submitButton.textContent = originalLabel;
         alert(validation.error);
         return;
     }
@@ -55,6 +64,8 @@ document.querySelector('form').addEventListener('submit', async function(e) {
     if (result.success) {
         window.location.href = 'dashboard.html';
     } else {
+        submitButton.disabled = false;
+        submitButton.textContent = originalLabel;
         alert('Error: ' + result.error);
     }
 });

--- a/public/app/js/pages/account-crew-page.js
+++ b/public/app/js/pages/account-crew-page.js
@@ -11,8 +11,29 @@ if (await isSignedIn()) {
     window.location.href = 'dashboard.html';
 }
 
+// Toggle mobile field visibility when WhatsApp checkbox changes
+const whatsappCheckbox = document.getElementById('whatsapp_group');
+const mobileGroup = document.getElementById('mobile-group');
+const mobileInput = document.getElementById('mobile');
+
+whatsappCheckbox.addEventListener('change', function() {
+    if (this.checked) {
+        mobileGroup.style.display = '';
+        mobileInput.required = true;
+    } else {
+        mobileGroup.style.display = 'none';
+        mobileInput.required = false;
+        mobileInput.value = '';
+    }
+});
+
 document.querySelector('form').addEventListener('submit', async function(e) {
     e.preventDefault();
+
+    const submitButton = this.querySelector('[type="submit"]');
+    const originalLabel = submitButton.textContent;
+    submitButton.disabled = true;
+    submitButton.textContent = 'Creating account...';
 
     // Get password values
     const password = document.getElementById('password').value;
@@ -20,6 +41,8 @@ document.querySelector('form').addEventListener('submit', async function(e) {
 
     // Validate passwords match
     if (password !== confirmPassword) {
+        submitButton.disabled = false;
+        submitButton.textContent = originalLabel;
         alert('Passwords do not match! Please try again.');
         return;
     }
@@ -27,7 +50,20 @@ document.querySelector('form').addEventListener('submit', async function(e) {
     // Validate password requirements
     const validation = validatePassword(password);
     if (!validation.isValid) {
+        submitButton.disabled = false;
+        submitButton.textContent = originalLabel;
         alert(validation.error);
+        return;
+    }
+
+    // Validate mobile is provided when WhatsApp is checked
+    const wantsWhatsapp = whatsappCheckbox.checked;
+    const mobile = mobileInput.value.trim();
+    if (wantsWhatsapp && !mobile) {
+        submitButton.disabled = false;
+        submitButton.textContent = originalLabel;
+        alert('Please enter your mobile number to join the WhatsApp group.');
+        mobileInput.focus();
         return;
     }
 
@@ -41,7 +77,8 @@ document.querySelector('form').addEventListener('submit', async function(e) {
             lastName: document.getElementById('last_name').value,
             membershipNumber: document.getElementById('membership_number').value,
             experience: document.getElementById('experience').value,
-            socialPreference: document.getElementById('whatsapp_group').checked
+            socialPreference: wantsWhatsapp,
+            ...(wantsWhatsapp && mobile ? { mobile } : {})
         }
     };
 
@@ -51,6 +88,8 @@ document.querySelector('form').addEventListener('submit', async function(e) {
     if (result.success) {
         window.location.href = 'dashboard.html';
     } else {
+        submitButton.disabled = false;
+        submitButton.textContent = originalLabel;
         alert('Error: ' + result.error);
     }
 });

--- a/public/app/js/pages/dashboard-page.js
+++ b/public/app/js/pages/dashboard-page.js
@@ -78,6 +78,12 @@ if (user.accountType === 'crew') {
             <span class="profile-label">WhatsApp Group:</span>
             <span class="profile-value">${user.profile.whatsappGroup ? 'Yes, enrolled' : 'Not enrolled'}</span>
         </div>
+        ${user.profile.mobile ? `
+        <div class="profile-item">
+            <span class="profile-label">Mobile:</span>
+            <span class="profile-value">${user.profile.mobile}</span>
+        </div>
+        ` : ''}
     `;
 } else {
     profileHTML = `

--- a/public/app/js/pages/edit-profile-page.js
+++ b/public/app/js/pages/edit-profile-page.js
@@ -26,7 +26,7 @@ if (!user) {
 }
 
 // Update navigation with user info
-updateAuthenticatedNavigation(user);
+updateAuthenticatedNavigation(user, signOut);
 
 // Add admin link if user is admin
 addAdminLink(user);
@@ -79,6 +79,12 @@ if (user.accountType === 'crew') {
             <small>Stay connected with other sailors and get event updates!</small>
         </div>
 
+        <div class="form-group" id="mobile-group" style="display: ${user.profile.whatsappGroup || user.profile.mobile ? '' : 'none'};">
+            <label for="mobile">Mobile Number${user.profile.whatsappGroup ? ' *' : ''}</label>
+            <input type="tel" id="mobile" name="mobile" placeholder="(555) 123-4567" value="${user.profile.mobile || ''}" ${user.profile.whatsappGroup ? 'required' : ''}>
+            <small>Required to add you to the WhatsApp group.</small>
+        </div>
+
         <h2 style="margin-top: 4rem; margin-bottom: 2rem;">Change Password (Optional)</h2>
 
         <div class="form-group">
@@ -122,7 +128,7 @@ if (user.accountType === 'crew') {
         <div class="form-group">
             <label for="phone">Phone Number *</label>
             <input type="tel" id="phone" name="phone" required placeholder="(555) 123-4567" value="${user.profile.phone}">
-            <small>For weather-related morning calls from the coordinator.</small>
+            <small>For weather-related morning calls and the WhatsApp group (if you join).</small>
         </div>
 
         <h2 style="margin-top: 4rem; margin-bottom: 2rem;">About Your Boat</h2>
@@ -201,6 +207,26 @@ if (user.accountType === 'crew') {
 
 formContent.innerHTML = formHTML;
 
+// Wire up WhatsApp → mobile toggle for crew
+if (user.accountType === 'crew') {
+    const whatsappCheckbox = document.getElementById('whatsapp_group');
+    const mobileGroup = document.getElementById('mobile-group');
+    const mobileInput = document.getElementById('mobile');
+    const mobileLabel = mobileGroup.querySelector('label');
+
+    whatsappCheckbox.addEventListener('change', function() {
+        if (this.checked) {
+            mobileGroup.style.display = '';
+            mobileInput.required = true;
+            mobileLabel.textContent = 'Mobile Number *';
+        } else {
+            mobileGroup.style.display = 'none';
+            mobileInput.required = false;
+            mobileLabel.textContent = 'Mobile Number';
+        }
+    });
+}
+
 // Handle form submission
 document.getElementById('edit-profile-form').addEventListener('submit', async function(e) {
     e.preventDefault();
@@ -254,7 +280,8 @@ document.getElementById('edit-profile-form').addEventListener('submit', async fu
             lastName: document.getElementById('last_name').value,
             membershipNumber: document.getElementById('membership_number').value,
             experience: document.getElementById('experience').value,
-            socialPreference: document.getElementById('whatsapp_group').checked
+            socialPreference: document.getElementById('whatsapp_group').checked,
+            mobile: document.getElementById('mobile').value
         };
     } else {
         profileUpdates = {

--- a/public/app/js/pages/signin-page.js
+++ b/public/app/js/pages/signin-page.js
@@ -18,6 +18,11 @@ const form = document.getElementById('signin-form');
 form.addEventListener('submit', async function(e) {
     e.preventDefault();
 
+    const submitButton = this.querySelector('[type="submit"]');
+    const originalLabel = submitButton.textContent;
+    submitButton.disabled = true;
+    submitButton.textContent = 'Signing in...';
+
     // Get form values
     const email = document.getElementById('email').value;
     const password = document.getElementById('password').value;
@@ -32,6 +37,9 @@ form.addEventListener('submit', async function(e) {
         // Redirect to admin dashboard if admin, otherwise regular dashboard
         window.location.href = user?.isAdmin ? 'admin.html' : 'dashboard.html';
     } else {
+        submitButton.disabled = false;
+        submitButton.textContent = originalLabel;
+
         // Show error message as toast (stays visible for 4 seconds)
         showError(result.error, 4000);
 


### PR DESCRIPTION
This partially address #49 

- Crew registration: show/hide mobile field conditionally when WhatsApp checkbox is ticked; field is required when visible
- Edit profile (crew): same conditional mobile field, pre-populated from saved data; mobile included in profile update payload
- authService: map `mobile` field through the crew profile transform so it's available on `user.profile.mobile`
- Dashboard: display mobile number under WhatsApp Group for crew members
- Boat owner forms: update phone field and WhatsApp checkbox help text to clarify the number is used for the WhatsApp group
- Buttons: disable and show in-progress label during async submission on sign-in, crew registration, and boat owner registration forms; restore on failure
- Fix: pass `signOut` to `updateAuthenticatedNavigation` on edit profile page to resolve "signOut is not a function" error