### PR TITLE
feat: resolve display name clashes by appending incrementing suffix

### DIFF
--- a/src/Application/Port/Repository/BoatRepositoryInterface.php
+++ b/src/Application/Port/Repository/BoatRepositoryInterface.php
@@ -114,4 +114,12 @@ interface BoatRepositoryInterface
      * @return int
      */
     public function count(): int;
+
+    /**
+     * Check if a display name already exists in the boats table
+     *
+     * @param string $displayName
+     * @return bool
+     */
+    public function displayNameExists(string $displayName): bool;
 }

--- a/src/Application/Port/Repository/CrewRepositoryInterface.php
+++ b/src/Application/Port/Repository/CrewRepositoryInterface.php
@@ -142,4 +142,12 @@ interface CrewRepositoryInterface
      * @return int
      */
     public function count(): int;
+
+    /**
+     * Check if a display name already exists in the crews table
+     *
+     * @param string $displayName
+     * @return bool
+     */
+    public function displayNameExists(string $displayName): bool;
 }

--- a/src/Application/UseCase/Auth/RegisterUseCase.php
+++ b/src/Application/UseCase/Auth/RegisterUseCase.php
@@ -159,6 +159,28 @@ class RegisterUseCase
     }
 
     /**
+     * Resolve a unique display name by appending an incrementing counter on collision.
+     *
+     * Returns $base if it is available, otherwise tries $base . "2", $base . "3", …
+     * until a free name is found.
+     *
+     * @param string   $base   The desired display name
+     * @param callable $exists fn(string $name): bool — returns true when the name is taken
+     * @return string          A display name that does not yet exist
+     */
+    private function resolveUniqueDisplayName(string $base, callable $exists): string
+    {
+        if (!$exists($base)) {
+            return $base;
+        }
+        $counter = 2;
+        while ($exists($base . $counter)) {
+            $counter++;
+        }
+        return $base . $counter;
+    }
+
+    /**
      * Create crew profile
      *
      * @param User $user User entity
@@ -183,6 +205,12 @@ class RegisterUseCase
                 $profile['lastName']
             );
         }
+
+        // Ensure display name is unique within the crew namespace
+        $displayName = $this->resolveUniqueDisplayName(
+            $displayName,
+            fn($name) => $this->crewRepository->displayNameExists($name)
+        );
 
         // Create crew entity
         $crew = new Crew(
@@ -237,10 +265,16 @@ class RegisterUseCase
             );
         }
 
+        // Ensure display name is unique within the boat namespace
+        $displayName = $this->resolveUniqueDisplayName(
+            $displayName,
+            fn($name) => $this->boatRepository->displayNameExists($name)
+        );
+
         // Use displayName for boat key
         $boatKey = BoatKey::fromBoatName($displayName);
 
-        // Check if boat already exists with this key
+        // Check if boat already exists with this key (safeguard for explicitly-provided names)
         $existingBoat = $this->boatRepository->findByKey($boatKey);
         if ($existingBoat !== null) {
             throw new ValidationException(['profile' => 'A boat with this name already exists']);

--- a/src/Application/UseCase/Season/ProcessSeasonUpdateUseCase.php
+++ b/src/Application/UseCase/Season/ProcessSeasonUpdateUseCase.php
@@ -76,7 +76,14 @@ class ProcessSeasonUpdateUseCase
             $selectionResult = $this->runSelection($fleet, $squad, $eventId);
 
             // Add flex boat owners to crew waitlist when their boat is cut
-            $flexCrewEntries = $this->buildFlexCrewEntries($selectionResult['waitlisted_boats']);
+            $existingCrewDisplayNames = array_values(array_filter(
+                array_map(fn($c) => $c->getDisplayName(), $squad->all()),
+                fn($name) => $name !== null
+            ));
+            $flexCrewEntries = $this->buildFlexCrewEntries(
+                $selectionResult['waitlisted_boats'],
+                $existingCrewDisplayNames
+            );
             $selectionResult['waitlisted_crews'] = array_merge(
                 $selectionResult['waitlisted_crews'],
                 $flexCrewEntries
@@ -357,22 +364,56 @@ class ProcessSeasonUpdateUseCase
     }
 
     /**
+     * Resolve a unique display name by appending an incrementing counter on collision.
+     *
+     * Returns $base if it is available (not in $usedNames), otherwise tries
+     * $base . "2", $base . "3", … until a free name is found.
+     *
+     * @param string   $base      The desired display name
+     * @param callable $exists    fn(string $name): bool — returns true when the name is taken
+     * @return string             A display name that is not taken
+     */
+    private function resolveUniqueDisplayName(string $base, callable $exists): string
+    {
+        if (!$exists($base)) {
+            return $base;
+        }
+        $counter = 2;
+        while ($exists($base . $counter)) {
+            $counter++;
+        }
+        return $base . $counter;
+    }
+
+    /**
      * Build Crew entities for flex boat owners whose boat was waitlisted
      *
      * When a flex boat (rank_flexibility=0) is waitlisted, its owner should appear
      * in the crew waitlist so they can be promoted to another boat with spare capacity.
      *
-     * @param array<Boat> $waitlistedBoats Boats that were not selected
+     * Display names are resolved against both the real crew squad and previously
+     * created flex entries in the same pass.
+     *
+     * @param array<Boat>   $waitlistedBoats      Boats that were not selected
+     * @param array<string> $existingDisplayNames  Display names already in use by real crew
      * @return array<Crew> Crew entities for flex boat owners
      */
-    private function buildFlexCrewEntries(array $waitlistedBoats): array
+    private function buildFlexCrewEntries(array $waitlistedBoats, array $existingDisplayNames): array
     {
         $entries = [];
+        $usedNames = $existingDisplayNames;
+
         foreach ($waitlistedBoats as $boat) {
             if ($boat->isWillingToCrew()) {
+                $displayName = $this->resolveUniqueDisplayName(
+                    $boat->getOwnerDisplayName(),
+                    fn($name) => in_array($name, $usedNames, true)
+                );
+                $usedNames[] = $displayName;
+
                 $crew = new Crew(
                     key: CrewKey::fromName($boat->getOwnerFirstName(), $boat->getOwnerLastName()),
-                    displayName: $boat->getOwnerDisplayName(),
+                    displayName: $displayName,
                     firstName: $boat->getOwnerFirstName(),
                     lastName: $boat->getOwnerLastName(),
                     partnerKey: null,

--- a/src/Application/UseCase/User/AddProfileUseCase.php
+++ b/src/Application/UseCase/User/AddProfileUseCase.php
@@ -68,6 +68,28 @@ class AddProfileUseCase
     }
 
     /**
+     * Resolve a unique display name by appending an incrementing counter on collision.
+     *
+     * Returns $base if it is available, otherwise tries $base . "2", $base . "3", …
+     * until a free name is found.
+     *
+     * @param string   $base   The desired display name
+     * @param callable $exists fn(string $name): bool — returns true when the name is taken
+     * @return string          A display name that does not yet exist
+     */
+    private function resolveUniqueDisplayName(string $base, callable $exists): string
+    {
+        if (!$exists($base)) {
+            return $base;
+        }
+        $counter = 2;
+        while ($exists($base . $counter)) {
+            $counter++;
+        }
+        return $base . $counter;
+    }
+
+    /**
      * Add crew profile
      *
      * @param int $userId User ID
@@ -92,10 +114,21 @@ class AddProfileUseCase
             throw new ValidationException(['crewProfile' => 'A crew member with this name already exists']);
         }
 
+        // Generate displayName if not provided, then resolve clashes
+        $displayName = $profile['displayName'] ?? null;
+        if ($displayName === null || trim($displayName) === '') {
+            $lastInitial = mb_substr($profile['lastName'], 0, 1);
+            $displayName = trim($profile['firstName']) . $lastInitial;
+        }
+        $displayName = $this->resolveUniqueDisplayName(
+            $displayName,
+            fn($name) => $this->crewRepository->displayNameExists($name)
+        );
+
         // Create crew entity
         $crew = new Crew(
             key: $crewKey,
-            displayName: $profile['displayName'] ?? null,
+            displayName: $displayName,
             firstName: $profile['firstName'],
             lastName: $profile['lastName'],
             partnerKey: isset($profile['partnerKey']) ? new CrewKey($profile['partnerKey']) : null,
@@ -135,17 +168,19 @@ class AddProfileUseCase
             throw new ValidationException(['boat_profile' => 'User already has a boat profile']);
         }
 
-        // If no displayName provided, generate key from owner's name; otherwise use displayName
+        // Generate displayName if not provided, then resolve clashes
         $displayName = $profile['displayName'] ?? null;
-        if ($displayName !== null && trim($displayName) !== '') {
-            $boatKey = BoatKey::fromBoatName($displayName);
-        } else {
-            // Generate key from owner's name if no boat name provided
-            $keyName = trim($profile['ownerFirstName']) . trim($profile['ownerLastName']);
-            $boatKey = BoatKey::fromBoatName($keyName);
+        if ($displayName === null || trim($displayName) === '') {
+            $lastInitial = mb_substr($profile['ownerLastName'], 0, 1);
+            $displayName = trim($profile['ownerFirstName']) . $lastInitial;
         }
+        $displayName = $this->resolveUniqueDisplayName(
+            $displayName,
+            fn($name) => $this->boatRepository->displayNameExists($name)
+        );
+        $boatKey = BoatKey::fromBoatName($displayName);
 
-        // Check if boat key already exists (different user with same boat name)
+        // Check if boat key already exists (safeguard for explicitly-provided names)
         $existingBoatByKey = $this->boatRepository->findByKey($boatKey);
         if ($existingBoatByKey !== null) {
             throw new ValidationException(['boatProfile' => 'A boat with this name already exists']);

--- a/src/Infrastructure/Persistence/SQLite/BoatRepository.php
+++ b/src/Infrastructure/Persistence/SQLite/BoatRepository.php
@@ -204,6 +204,13 @@ class BoatRepository implements BoatRepositoryInterface
         return (int)$stmt->fetchColumn();
     }
 
+    public function displayNameExists(string $displayName): bool
+    {
+        $stmt = $this->pdo->prepare('SELECT COUNT(*) FROM boats WHERE display_name = :display_name');
+        $stmt->execute(['display_name' => $displayName]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
     /**
      * Insert new boat
      */

--- a/src/Infrastructure/Persistence/SQLite/CrewRepository.php
+++ b/src/Infrastructure/Persistence/SQLite/CrewRepository.php
@@ -257,6 +257,13 @@ class CrewRepository implements CrewRepositoryInterface
         return (int)$stmt->fetchColumn();
     }
 
+    public function displayNameExists(string $displayName): bool
+    {
+        $stmt = $this->pdo->prepare('SELECT COUNT(*) FROM crews WHERE display_name = :display_name');
+        $stmt->execute(['display_name' => $displayName]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
     /**
      * Insert new crew
      */

--- a/tests/Integration/Application/UseCase/Auth/RegisterUseCaseTest.php
+++ b/tests/Integration/Application/UseCase/Auth/RegisterUseCaseTest.php
@@ -413,16 +413,16 @@ class RegisterUseCaseTest extends IntegrationTestCase
         $this->useCase->execute($request2);
     }
 
-    public function testRegisterBoatWithDuplicateNameThrowsValidationException(): void
+    public function testRegisterBoatWithSameLastInitialGetsUniqueDisplayName(): void
     {
-        // Register first boat
+        // Register first boat owner: John Doe → "JohnD"
         $request1 = RegisterRequest::fromArray([
-            'email' => 'boat1@example.com',
+            'email' => 'john.doe@example.com',
             'password' => 'SecurePassword123',
             'accountType' => 'boat_owner',
             'profile' => [
-                'ownerFirstName' => 'Duplicate',
-                'ownerLastName' => 'Owner',
+                'ownerFirstName' => 'John',
+                'ownerLastName' => 'Doe',
                 'minBerths' => 2,
                 'maxBerths' => 6,
                 'ownerMobile' => '555-0001',
@@ -430,23 +430,90 @@ class RegisterUseCaseTest extends IntegrationTestCase
         ]);
         $this->useCase->execute($request1);
 
-        // Try to register second boat with same owner (same display name)
+        // Register second boat owner with same first-name + last-initial: John Davidson → "JohnD2"
         $request2 = RegisterRequest::fromArray([
-            'email' => 'boat2@example.com',
+            'email' => 'john.davidson@example.com',
             'password' => 'SecurePassword123',
             'accountType' => 'boat_owner',
             'profile' => [
-                'ownerFirstName' => 'Duplicate',
-                'ownerLastName' => 'Owner',
+                'ownerFirstName' => 'John',
+                'ownerLastName' => 'Davidson',
                 'minBerths' => 4,
                 'maxBerths' => 8,
                 'ownerMobile' => '555-0002',
             ]
         ]);
-
-        $this->expectException(ValidationException::class);
-
         $this->useCase->execute($request2);
+
+        $boat1 = $this->boatRepository->findByOwnerName('John', 'Doe');
+        $boat2 = $this->boatRepository->findByOwnerName('John', 'Davidson');
+
+        $this->assertNotNull($boat1);
+        $this->assertNotNull($boat2);
+        $this->assertEquals('JohnD', $boat1->getDisplayName());
+        $this->assertEquals('JohnD2', $boat2->getDisplayName());
+        // Keys are derived from display names
+        $this->assertEquals('johnd', $boat1->getKey()->toString());
+        $this->assertEquals('johnd2', $boat2->getKey()->toString());
+    }
+
+    public function testRegisterBoatWithThirdClashGetsIncrementedSuffix(): void
+    {
+        // Three owners all generating "JohnD"
+        foreach (['Doe', 'Davidson', 'Denver'] as $i => $lastName) {
+            $request = RegisterRequest::fromArray([
+                'email' => "john.{$lastName}@example.com",
+                'password' => 'SecurePassword123',
+                'accountType' => 'boat_owner',
+                'profile' => [
+                    'ownerFirstName' => 'John',
+                    'ownerLastName' => $lastName,
+                    'minBerths' => 2,
+                    'maxBerths' => 4,
+                    'ownerMobile' => "555-000{$i}",
+                ]
+            ]);
+            $this->useCase->execute($request);
+        }
+
+        $this->assertEquals('JohnD', $this->boatRepository->findByOwnerName('John', 'Doe')->getDisplayName());
+        $this->assertEquals('JohnD2', $this->boatRepository->findByOwnerName('John', 'Davidson')->getDisplayName());
+        $this->assertEquals('JohnD3', $this->boatRepository->findByOwnerName('John', 'Denver')->getDisplayName());
+    }
+
+    public function testRegisterCrewWithSameLastInitialGetsUniqueDisplayName(): void
+    {
+        // Register first crew: John Doe → "JohnD"
+        $request1 = RegisterRequest::fromArray([
+            'email' => 'john.doe@example.com',
+            'password' => 'SecurePassword123',
+            'accountType' => 'crew',
+            'profile' => [
+                'firstName' => 'John',
+                'lastName' => 'Doe',
+            ]
+        ]);
+        $this->useCase->execute($request1);
+
+        // Register second crew with same first-name + last-initial: John Denver → "JohnD2"
+        $request2 = RegisterRequest::fromArray([
+            'email' => 'john.denver@example.com',
+            'password' => 'SecurePassword123',
+            'accountType' => 'crew',
+            'profile' => [
+                'firstName' => 'John',
+                'lastName' => 'Denver',
+            ]
+        ]);
+        $this->useCase->execute($request2);
+
+        $crew1 = $this->crewRepository->findByName('John', 'Doe');
+        $crew2 = $this->crewRepository->findByName('John', 'Denver');
+
+        $this->assertNotNull($crew1);
+        $this->assertNotNull($crew2);
+        $this->assertEquals('JohnD', $crew1->getDisplayName());
+        $this->assertEquals('JohnD2', $crew2->getDisplayName());
     }
 
     public function testRegisterCrewPopulatesWhitelistWithAllBoats(): void

--- a/tests/Unit/Application/UseCase/Auth/RegisterUseCaseTest.php
+++ b/tests/Unit/Application/UseCase/Auth/RegisterUseCaseTest.php
@@ -61,6 +61,10 @@ class RegisterUseCaseTest extends TestCase
         $this->tokenService->method('generate')->willReturn('mock.jwt.token');
         $this->tokenService->method('getExpirationMinutes')->willReturn(60);
 
+        // Default: no display name clashes
+        $this->crewRepository->method('displayNameExists')->willReturn(false);
+        $this->boatRepository->method('displayNameExists')->willReturn(false);
+
         // Mock user save to set ID
         $this->userRepository->method('save')->willReturnCallback(function ($user) {
             // Set user ID after save
@@ -606,6 +610,104 @@ class RegisterUseCaseTest extends TestCase
         $this->assertStringContainsString('12345', $capturedEmailBody); // membership number
         $this->assertStringContainsString('555-1234', $capturedEmailBody); // mobile
         $this->assertStringContainsString('detailed@example.com', $capturedEmailBody); // email
+    }
+
+    public function testCrewDisplayNameSuffixedOnClash(): void
+    {
+        // Arrange: first call ("JohnD") clashes, second call ("JohnD2") is free
+        $this->crewRepository = $this->createMock(CrewRepositoryInterface::class);
+        $this->crewRepository->method('findByKey')->willReturn(null);
+        $this->crewRepository->method('displayNameExists')
+            ->willReturnCallback(fn($name) => $name === 'JohnD');  // 'JohnD' taken, 'JohnD2' free
+
+        $capturedCrew = null;
+        $this->crewRepository->expects($this->once())
+            ->method('save')
+            ->with($this->callback(function (Crew $crew) use (&$capturedCrew) {
+                $capturedCrew = $crew;
+                return true;
+            }));
+
+        // Rebuild use case with the new mock
+        $this->useCase = new RegisterUseCase(
+            $this->userRepository,
+            $this->crewRepository,
+            $this->boatRepository,
+            $this->passwordService,
+            $this->tokenService,
+            $this->rankingService,
+            $this->emailService,
+            $this->emailTemplateService,
+            $this->config
+        );
+
+        $request = new RegisterRequest(
+            email: 'john.denver@example.com',
+            password: 'SecurePass123!',
+            accountType: 'crew',
+            profile: [
+                'firstName' => 'John',
+                'lastName' => 'Denver',
+            ]
+        );
+
+        // Act
+        $this->useCase->execute($request);
+
+        // Assert: display name got the "2" suffix because "JohnD" was taken
+        $this->assertNotNull($capturedCrew);
+        $this->assertEquals('JohnD2', $capturedCrew->getDisplayName());
+    }
+
+    public function testBoatDisplayNameSuffixedOnClash(): void
+    {
+        // Arrange: "JohnD" is taken, "JohnD2" is free
+        $this->boatRepository = $this->createMock(BoatRepositoryInterface::class);
+        $this->boatRepository->method('findByKey')->willReturn(null);
+        $this->boatRepository->method('displayNameExists')
+            ->willReturnCallback(fn($name) => $name === 'JohnD');
+        $this->boatRepository->method('findAll')->willReturn([]);
+
+        $capturedBoat = null;
+        $this->boatRepository->expects($this->once())
+            ->method('save')
+            ->with($this->callback(function (Boat $boat) use (&$capturedBoat) {
+                $capturedBoat = $boat;
+                return true;
+            }));
+
+        // Rebuild use case with the new mock
+        $this->useCase = new RegisterUseCase(
+            $this->userRepository,
+            $this->crewRepository,
+            $this->boatRepository,
+            $this->passwordService,
+            $this->tokenService,
+            $this->rankingService,
+            $this->emailService,
+            $this->emailTemplateService,
+            $this->config
+        );
+
+        $request = new RegisterRequest(
+            email: 'john.davidson@example.com',
+            password: 'SecurePass123!',
+            accountType: 'boat_owner',
+            profile: [
+                'ownerFirstName' => 'John',
+                'ownerLastName' => 'Davidson',
+                'minBerths' => 2,
+                'maxBerths' => 4,
+            ]
+        );
+
+        // Act
+        $this->useCase->execute($request);
+
+        // Assert: display name got the "2" suffix because "JohnD" was taken
+        $this->assertNotNull($capturedBoat);
+        $this->assertEquals('JohnD2', $capturedBoat->getDisplayName());
+        $this->assertEquals('johnd2', $capturedBoat->getKey()->toString());
     }
 
     public function testEmailContainsBoatDetailsForBoatOwnerRegistration(): void


### PR DESCRIPTION
When a generated display name (FirstNameL) already exists, append "2", "3", etc. until a unique name is found, instead of silently colliding (crew) or throwing a generic validation error (boat).

- Add displayNameExists() to BoatRepositoryInterface, CrewRepositoryInterface, and their SQLite implementations
- Add resolveUniqueDisplayName() helper to RegisterUseCase, AddProfileUseCase, and ProcessSeasonUpdateUseCase
- Fix AddProfileUseCase to auto-generate FirstNameL display name (was using FirstNameLastName) and apply clash resolution for both crew and boat profiles
- Update buildFlexCrewEntries() to resolve clashes against real crew display names and previously-created flex entries in the same pass
- Add unit tests for crew and boat suffix collision cases
- Add integration tests: same last-initial produces unique display names, third clash increments to suffix 3

Resolves #57 