### PR TITLE
docs(faq): clarify AWS verification email flow

### DIFF
--- a/public/app/faq.html
+++ b/public/app/faq.html
@@ -67,6 +67,7 @@
             <div class="faq-item">
                 <h3>Why did I get a random AWS email?</h3>
                 <p>That's just email verification! It's optional but recommended—it'll let us send you reminders and cool notifications in the future. The admin kicks off this process.</p>
+                <p>AWS will offer you an opportunity to create an account. This can safely be ignored.</p>
             </div>
 
             <div class="faq-item">


### PR DESCRIPTION
Add FAQ note that AWS may prompt users to create an account during email verification and that this step can be safely ignored.

Closes #68 