### PR TITLE
feat: add concurrency lock to ProcessSeasonUpdateUseCase

### DIFF
--- a/config/container.php
+++ b/config/container.php
@@ -22,6 +22,7 @@ use App\Application\Port\Service\CalendarServiceInterface;
 use App\Application\Port\Service\TimeServiceInterface;
 use App\Application\Port\Service\TokenServiceInterface;
 use App\Application\Port\Service\PasswordServiceInterface;
+use App\Application\Port\Service\LockServiceInterface;
 use App\Application\Port\Service\TransactionServiceInterface;
 use App\Infrastructure\Persistence\SQLite\BoatRepository;
 use App\Infrastructure\Persistence\SQLite\CrewRepository;
@@ -36,6 +37,7 @@ use App\Infrastructure\Service\SystemTimeService;
 use App\Infrastructure\Service\JwtTokenService;
 use App\Infrastructure\Service\PhpPasswordService;
 use App\Infrastructure\Service\DatabaseTransactionService;
+use App\Infrastructure\Service\SQLiteLockService;
 use App\Domain\Service\SelectionService;
 use App\Domain\Service\AssignmentService;
 use App\Domain\Service\RankingService;
@@ -143,6 +145,10 @@ $container->set(TransactionServiceInterface::class, function () {
     return new DatabaseTransactionService();
 });
 
+$container->set(LockServiceInterface::class, function () {
+    return new SQLiteLockService();
+});
+
 // =======================
 // Domain Layer
 // =======================
@@ -233,7 +239,8 @@ $container->set(\App\Application\UseCase\Season\ProcessSeasonUpdateUseCase::clas
         $c->get(SelectionService::class),
         $c->get(AssignmentService::class),
         $c->get(RankingService::class),
-        $c->get(TransactionServiceInterface::class)
+        $c->get(TransactionServiceInterface::class),
+        $c->get(LockServiceInterface::class)
     );
 });
 

--- a/database/migrations/20260302000000_create_locks_table.php
+++ b/database/migrations/20260302000000_create_locks_table.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Create Locks Table Migration
+ *
+ * Creates locks table for application-level concurrency control:
+ * - Prevents race conditions in ProcessSeasonUpdateUseCase
+ * - Uses database table for advisory lock simulation (SQLite lacks native advisory locks)
+ * - Supports automatic cleanup of expired locks from crashed processes
+ *
+ * Purpose: Enable serialization of concurrent season update pipeline executions
+ *
+ * Lock Mechanism:
+ * - Lock acquisition via INSERT (unique constraint prevents duplicates)
+ * - Lock expiration via expires_at (auto-cleanup on next acquire attempt)
+ * - Process tracking via acquired_by (debugging crashed processes)
+ */
+final class CreateLocksTable extends AbstractMigration
+{
+    /**
+     * Create locks table for application-level locking
+     */
+    public function change(): void
+    {
+        // ====================================================================
+        // Table: locks
+        // Stores active application-level locks for concurrency control
+        // ====================================================================
+        $locks = $this->table('locks', ['id' => false, 'primary_key' => 'lock_name']);
+        $locks->addColumn('lock_name', 'string', ['limit' => 255, 'null' => false])
+              ->addColumn('acquired_at', 'datetime', ['null' => false])
+              ->addColumn('acquired_by', 'string', ['limit' => 255, 'null' => false, 'comment' => 'Process ID for debugging'])
+              ->addColumn('expires_at', 'datetime', ['null' => false, 'comment' => 'Auto-cleanup timestamp'])
+              ->addIndex(['expires_at'], ['name' => 'idx_locks_expires_at'])
+              ->create();
+    }
+}

--- a/public/app/js/apiService.js
+++ b/public/app/js/apiService.js
@@ -5,14 +5,25 @@
 
 import { API_CONFIG, buildApiUrl } from './config.js';
 import { getToken, clearToken } from './tokenService.js';
+import { showInfo } from './toastService.js';
 
 /**
- * Make HTTP request to API
+ * Sleep for specified milliseconds
+ * @param {number} ms - Milliseconds to sleep
+ * @returns {Promise<void>}
+ */
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Make HTTP request to API with automatic retry on 409 Conflict
  * @param {string} url - Full API URL
  * @param {Object} options - Fetch options
+ * @param {number} retryCount - Current retry attempt (internal)
  * @returns {Promise<Object>} Response data
  */
-async function makeRequest(url, options = {}) {
+async function makeRequest(url, options = {}, retryCount = 0) {
     try {
         // Get JWT token for authentication
         const token = getToken();
@@ -45,6 +56,32 @@ async function makeRequest(url, options = {}) {
             }
 
             throw new Error('Session expired. Please sign in again.');
+        }
+
+        // Handle 409 Conflict - concurrent update in progress (retry with exponential backoff)
+        if (response.status === 409) {
+            const maxRetries = 3;
+            const baseDelay = 2000; // 2 seconds
+
+            if (retryCount < maxRetries) {
+                const delay = baseDelay * Math.pow(1.5, retryCount); // Exponential backoff: 2s, 3s, 4.5s
+                const attemptNumber = retryCount + 1;
+
+                showInfo(
+                    `Season update in progress. Retrying in ${Math.round(delay / 1000)} seconds... (Attempt ${attemptNumber}/${maxRetries})`,
+                    delay
+                );
+
+                await sleep(delay);
+                return makeRequest(url, options, retryCount + 1);
+            } else {
+                // Max retries exceeded
+                const errorData = await response.json().catch(() => ({}));
+                throw new Error(
+                    errorData.message ||
+                    'Server is busy processing updates. Please try again in a moment.'
+                );
+            }
         }
 
         if (!response.ok) {

--- a/src/Application/Exception/LockTimeoutException.php
+++ b/src/Application/Exception/LockTimeoutException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Exception;
+
+/**
+ * Lock Timeout Exception
+ *
+ * Thrown when a lock cannot be acquired within the specified wait time.
+ * This typically occurs when multiple users are updating data concurrently
+ * and one request must wait for another to complete.
+ *
+ * Maps to HTTP 409 Conflict status code.
+ */
+class LockTimeoutException extends \RuntimeException
+{
+    public function __construct(string $lockName, int $waitSeconds)
+    {
+        parent::__construct(
+            sprintf(
+                'Could not acquire lock "%s" within %d seconds. Another process is holding the lock.',
+                $lockName,
+                $waitSeconds
+            )
+        );
+    }
+}

--- a/src/Application/Port/Service/LockServiceInterface.php
+++ b/src/Application/Port/Service/LockServiceInterface.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Port\Service;
+
+use App\Application\Exception\LockTimeoutException;
+
+/**
+ * Lock Service Interface
+ *
+ * Defines the contract for application-level distributed locking.
+ * Used to serialize access to critical sections (e.g., season update pipeline)
+ * and prevent race conditions when multiple users update data concurrently.
+ *
+ * Implementation note: SQLite lacks native advisory locks, so implementations
+ * typically use a database table with unique constraints for lock simulation.
+ */
+interface LockServiceInterface
+{
+    /**
+     * Attempt to acquire a named lock
+     *
+     * @param string $lockName Unique identifier for the lock (e.g., 'season_update_pipeline')
+     * @param int $timeoutSeconds Lock expiration time in seconds (default: 60)
+     * @return bool True if lock acquired, false if already held by another process
+     * @throws \RuntimeException If database error occurs during acquisition
+     */
+    public function acquire(string $lockName, int $timeoutSeconds = 60): bool;
+
+    /**
+     * Release a named lock
+     *
+     * @param string $lockName The lock to release
+     * @return void
+     * @throws \RuntimeException If lock does not exist or database error occurs
+     */
+    public function release(string $lockName): void;
+
+    /**
+     * Check if a named lock is currently held
+     *
+     * @param string $lockName The lock to check
+     * @return bool True if lock is held (and not expired), false otherwise
+     */
+    public function isLocked(string $lockName): bool;
+
+    /**
+     * Execute a callback with lock protection
+     *
+     * Acquires the lock, executes the callback, and releases the lock.
+     * Provides try-finally guarantee: lock is released even if callback throws.
+     * Supports waiting for lock with retry logic.
+     *
+     * @param string $lockName Unique identifier for the lock
+     * @param callable $callback Function to execute while holding lock
+     * @param int $timeoutSeconds Lock expiration time (default: 60)
+     * @param int $waitSeconds Maximum time to wait for lock acquisition (default: 10)
+     * @return mixed Return value from callback
+     * @throws LockTimeoutException If lock cannot be acquired within waitSeconds
+     * @throws \Throwable If callback throws an exception (lock is still released)
+     */
+    public function executeWithLock(
+        string $lockName,
+        callable $callback,
+        int $timeoutSeconds = 60,
+        int $waitSeconds = 10
+    ): mixed;
+}

--- a/src/Application/UseCase/Season/ProcessSeasonUpdateUseCase.php
+++ b/src/Application/UseCase/Season/ProcessSeasonUpdateUseCase.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace App\Application\UseCase\Season;
 
+use App\Application\Exception\LockTimeoutException;
 use App\Application\Port\Repository\BoatRepositoryInterface;
 use App\Application\Port\Repository\CrewRepositoryInterface;
 use App\Application\Port\Repository\EventRepositoryInterface;
 use App\Application\Port\Repository\SeasonRepositoryInterface;
+use App\Application\Port\Service\LockServiceInterface;
 use App\Application\Port\Service\TransactionServiceInterface;
 use App\Domain\Collection\Fleet;
 use App\Domain\Collection\Squad;
@@ -50,15 +52,42 @@ class ProcessSeasonUpdateUseCase
         private AssignmentService $assignmentService,
         private RankingService $rankingService,
         private TransactionServiceInterface $transactionService,
+        private LockServiceInterface $lockService,
     ) {
     }
 
     /**
-     * Execute the season update pipeline
+     * Execute the season update pipeline (with concurrency lock)
+     *
+     * Wraps run() in an application-level lock so that reads, compute,
+     * and writes all happen serially, preventing stale-read races.
      *
      * @return array{success: bool, events_processed: int, flotillas_generated: int}
      */
     public function execute(): array
+    {
+        try {
+            return $this->lockService->executeWithLock(
+                lockName: 'season_update_pipeline',
+                callback: fn() => $this->run(),
+                timeoutSeconds: 60,
+                waitSeconds: 10
+            );
+        } catch (LockTimeoutException $e) {
+            throw new \RuntimeException(
+                'Season update is currently in progress by another user. Please try again in a moment.',
+                409,
+                $e
+            );
+        }
+    }
+
+    /**
+     * Run the season update pipeline (reads + compute + writes)
+     *
+     * @return array{success: bool, events_processed: int, flotillas_generated: int}
+     */
+    private function run(): array
     {
         // Load all entities (reads only — outside the transaction)
         $fleet = $this->loadFleet();

--- a/src/Infrastructure/Persistence/SQLite/Connection.php
+++ b/src/Infrastructure/Persistence/SQLite/Connection.php
@@ -53,6 +53,9 @@ class Connection
                 // Enable WAL mode for better concurrency
                 self::$instance->exec('PRAGMA journal_mode = WAL');
 
+                // Set busy timeout as defense-in-depth for DB operations not covered by the lock
+                self::$instance->exec('PRAGMA busy_timeout = 5000');
+
             } catch (PDOException $e) {
                 throw new PDOException(
                     "Failed to connect to SQLite database at {$dbPath}: " . $e->getMessage(),

--- a/src/Infrastructure/Service/SQLiteLockService.php
+++ b/src/Infrastructure/Service/SQLiteLockService.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Service;
+
+use App\Application\Port\Service\LockServiceInterface;
+use App\Application\Exception\LockTimeoutException;
+use App\Infrastructure\Persistence\SQLite\Connection;
+use PDO;
+use PDOException;
+
+/**
+ * SQLite Lock Service
+ *
+ * Implements application-level distributed locking using a database table.
+ * SQLite lacks native advisory locks (unlike PostgreSQL), so we simulate
+ * them using a locks table with unique constraint on lock_name.
+ *
+ * Features:
+ * - Automatic cleanup of expired locks (from crashed processes)
+ * - Polling retry logic with configurable wait time
+ * - Process ID tracking for debugging
+ * - Try-finally guarantee for lock release
+ *
+ * Lock Mechanism:
+ * - Acquire: INSERT INTO locks (fails if lock exists due to unique constraint)
+ * - Release: DELETE FROM locks WHERE lock_name = ?
+ * - Expiration: DELETE FROM locks WHERE expires_at < CURRENT_TIMESTAMP
+ */
+class SQLiteLockService implements LockServiceInterface
+{
+    private PDO $pdo;
+
+    public function __construct(?PDO $pdo = null)
+    {
+        $this->pdo = $pdo ?? Connection::getInstance();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function acquire(string $lockName, int $timeoutSeconds = 60): bool
+    {
+        // Clean up expired locks first
+        $this->cleanupExpiredLocks();
+
+        // Calculate expiration timestamp
+        $expiresAt = date('Y-m-d H:i:s', time() + $timeoutSeconds);
+        $acquiredAt = date('Y-m-d H:i:s');
+        $acquiredBy = $this->getProcessId();
+
+        try {
+            $stmt = $this->pdo->prepare('
+                INSERT INTO locks (lock_name, acquired_at, acquired_by, expires_at)
+                VALUES (:lock_name, :acquired_at, :acquired_by, :expires_at)
+            ');
+
+            $stmt->execute([
+                ':lock_name' => $lockName,
+                ':acquired_at' => $acquiredAt,
+                ':acquired_by' => $acquiredBy,
+                ':expires_at' => $expiresAt,
+            ]);
+
+            return true;
+        } catch (PDOException $e) {
+            // Unique constraint violation means lock is already held
+            if ($e->getCode() === '23000' || strpos($e->getMessage(), 'UNIQUE constraint') !== false) {
+                return false;
+            }
+
+            // Other database errors should be thrown
+            throw new \RuntimeException(
+                "Failed to acquire lock '{$lockName}': " . $e->getMessage(),
+                0,
+                $e
+            );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function release(string $lockName): void
+    {
+        try {
+            $stmt = $this->pdo->prepare('DELETE FROM locks WHERE lock_name = :lock_name');
+            $stmt->execute([':lock_name' => $lockName]);
+
+            if ($stmt->rowCount() === 0) {
+                throw new \RuntimeException("Lock '{$lockName}' does not exist or was already released");
+            }
+        } catch (PDOException $e) {
+            throw new \RuntimeException(
+                "Failed to release lock '{$lockName}': " . $e->getMessage(),
+                0,
+                $e
+            );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isLocked(string $lockName): bool
+    {
+        // Clean up expired locks first
+        $this->cleanupExpiredLocks();
+
+        try {
+            $stmt = $this->pdo->prepare('
+                SELECT COUNT(*) FROM locks
+                WHERE lock_name = :lock_name
+                AND expires_at > :current_time
+            ');
+
+            $stmt->execute([
+                ':lock_name' => $lockName,
+                ':current_time' => date('Y-m-d H:i:s'),
+            ]);
+
+            return $stmt->fetchColumn() > 0;
+        } catch (PDOException $e) {
+            throw new \RuntimeException(
+                "Failed to check lock '{$lockName}': " . $e->getMessage(),
+                0,
+                $e
+            );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function executeWithLock(
+        string $lockName,
+        callable $callback,
+        int $timeoutSeconds = 60,
+        int $waitSeconds = 10
+    ): mixed {
+        // Try to acquire lock with retry logic
+        $acquired = $this->acquireWithRetry($lockName, $timeoutSeconds, $waitSeconds);
+
+        if (!$acquired) {
+            throw new LockTimeoutException($lockName, $waitSeconds);
+        }
+
+        try {
+            // Execute callback while holding lock
+            return $callback();
+        } finally {
+            // Always release lock, even if callback throws
+            try {
+                $this->release($lockName);
+            } catch (\RuntimeException $e) {
+                // Log but don't throw - we don't want to mask callback exceptions
+                error_log("Failed to release lock '{$lockName}': " . $e->getMessage());
+            }
+        }
+    }
+
+    /**
+     * Acquire lock with polling retry logic
+     *
+     * @param string $lockName
+     * @param int $timeoutSeconds Lock expiration time
+     * @param int $waitSeconds Maximum time to wait for lock
+     * @return bool True if acquired, false if timeout
+     */
+    private function acquireWithRetry(string $lockName, int $timeoutSeconds, int $waitSeconds): bool
+    {
+        $startTime = time();
+        $retryInterval = 100000; // 100ms in microseconds
+
+        while (true) {
+            // Try to acquire lock
+            if ($this->acquire($lockName, $timeoutSeconds)) {
+                return true;
+            }
+
+            // Check if we've exceeded wait time
+            if (time() - $startTime >= $waitSeconds) {
+                return false;
+            }
+
+            // Wait before retrying
+            usleep($retryInterval);
+        }
+    }
+
+    /**
+     * Clean up expired locks
+     *
+     * Removes locks that have exceeded their expiration time.
+     * This handles orphaned locks from crashed processes.
+     *
+     * @return void
+     */
+    private function cleanupExpiredLocks(): void
+    {
+        try {
+            $stmt = $this->pdo->prepare('DELETE FROM locks WHERE expires_at < :current_time');
+            $stmt->execute([':current_time' => date('Y-m-d H:i:s')]);
+        } catch (PDOException $e) {
+            // Log but don't throw - cleanup failure shouldn't prevent lock acquisition
+            error_log("Failed to clean up expired locks: " . $e->getMessage());
+        }
+    }
+
+    /**
+     * Get unique process identifier
+     *
+     * Combines process ID with unique ID for debugging.
+     * Format: "12345-507f191e810c19729de860ea"
+     *
+     * @return string
+     */
+    private function getProcessId(): string
+    {
+        return getmypid() . '-' . uniqid();
+    }
+}

--- a/src/Presentation/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Presentation/Middleware/ErrorHandlerMiddleware.php
@@ -62,6 +62,11 @@ class ErrorHandlerMiddleware
             return JsonResponse::error($e->getMessage(), 409);
         }
 
+        // Lock timeout / concurrent update (409 Conflict)
+        if ($e instanceof \RuntimeException && $e->getCode() === 409) {
+            return JsonResponse::error($e->getMessage(), 409);
+        }
+
         // Weak password (400 Bad Request)
         if ($e instanceof WeakPasswordException) {
             return JsonResponse::error($e->getMessage(), 400);

--- a/tests/Integration/Application/UseCase/Season/ProcessSeasonUpdateUseCaseTest.php
+++ b/tests/Integration/Application/UseCase/Season/ProcessSeasonUpdateUseCaseTest.php
@@ -9,13 +9,13 @@ use App\Infrastructure\Persistence\SQLite\BoatRepository;
 use App\Infrastructure\Persistence\SQLite\CrewRepository;
 use App\Infrastructure\Persistence\SQLite\EventRepository;
 use App\Infrastructure\Persistence\SQLite\SeasonRepository;
-use App\Infrastructure\Persistence\SQLite\Connection;
 use App\Domain\Service\SelectionService;
 use App\Domain\Service\AssignmentService;
 use App\Domain\Service\RankingService;
 use App\Domain\ValueObject\EventId;
 use App\Domain\Enum\AvailabilityStatus;
 use App\Infrastructure\Service\DatabaseTransactionService;
+use App\Infrastructure\Service\SQLiteLockService;
 use Tests\Integration\IntegrationTestCase;
 
 /**
@@ -56,7 +56,8 @@ class ProcessSeasonUpdateUseCaseTest extends IntegrationTestCase
             $selectionService,
             $assignmentService,
             $rankingService,
-            new DatabaseTransactionService()
+            new DatabaseTransactionService(),
+            new SQLiteLockService($this->pdo)
         );
     }
 

--- a/tests/Unit/Integration/IntegrationTestCaseTest.php
+++ b/tests/Unit/Integration/IntegrationTestCaseTest.php
@@ -39,7 +39,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         ")->fetchAll();
         $this->assertNotEmpty($result, 'phinxlog table should exist after running migrations');
 
-        // Verify all 6 migrations executed
+        // Verify all 7 migrations executed
         $versions = $this->pdo->query("
             SELECT version FROM phinxlog ORDER BY version
         ")->fetchAll(PDO::FETCH_COLUMN);
@@ -51,10 +51,11 @@ class IntegrationTestCaseTest extends IntegrationTestCase
             20260201000000,  // make_display_name_nullable
             20260221000000,  // remove_crew_rank_flexibility
             20260224000000,  // remove_email_columns
-            20260227000000   // add_cron_notifications
+            20260227000000,  // add_cron_notifications
+            20260302000000   // create_locks_table
         ];
 
-        $this->assertEquals($expected, $versions, 'All 7 migrations should be applied');
+        $this->assertEquals($expected, $versions, 'All 8 migrations should be applied');
     }
 
     public function testSeasonConfigInitialized(): void
@@ -118,6 +119,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
             'season_config',
             'flotillas',
             'users',
+            'locks',
             'phinxlog'
         ];
 


### PR DESCRIPTION
Eliminates the stale-read race condition where two concurrent requests could both read the same snapshot, compute independently, and the second writer would overwrite the first with a stale result.

- Add LockServiceInterface port and SQLiteLockService adapter (polling INSERT on a locks table with UNIQUE constraint, 100ms retry interval, expired-lock cleanup)
- Add locks table migration (20260225000000)
- Wrap ProcessSeasonUpdateUseCase::execute() in executeWithLock() so reads, compute, and writes all execute serially; original body moved to private run()
- Add PRAGMA busy_timeout = 5000 to Connection as defense-in-depth
- Map RuntimeException(409) to HTTP 409 in ErrorHandlerMiddleware
- Add exponential-backoff retry (3x, 2s/3s/4.5s) for 409 in apiService.js
- Update IntegrationTestCaseTest for 7 migrations and locks table

Fixes #77 