### PR TITLE
docs: update privacy messaging for registration and FAQ

### DIFF
--- a/public/app/account_crew.html
+++ b/public/app/account_crew.html
@@ -74,7 +74,6 @@
                     <div class="form-group">
                         <label for="email">Email *</label>
                         <input type="email" id="email" name="email" required placeholder="your.email@example.com">
-                        <small>You might get an AWS verification email—it's optional but lets us send you cool notifications!</small>
                     </div>
 
                     <div class="form-group">

--- a/public/app/faq.html
+++ b/public/app/faq.html
@@ -65,9 +65,13 @@
             </div>
 
             <div class="faq-item">
-                <h3>Why did I get a random AWS email?</h3>
-                <p>That's just email verification! It's optional but recommended—it'll let us send you reminders and cool notifications in the future. The admin kicks off this process.</p>
-                <p>AWS will offer you an opportunity to create an account. This can safely be ignored.</p>
+                <h3>How is my personal information handled?</h3>
+                <p>Your personal information is processed and/or stored by Nepean Sailing Club, Amazon Web Services and Mailjet. The related privacy poicies are described in the following resources.</p>
+                <ul>
+                    <li><a href="https://nsc.ca/nsc_members/board/policy_privacy.pdf" target="_blank">NSC - Privacy Policy</a></li>
+                    <li><a href="https://aws.amazon.com/privacy/" target="_blank">Amazon Web Services Privacy Policy</a></li>
+                    <li><a href="https://www.mailjet.com/legal/privacy/" target="_blank">Mailjet Privacy Policy</a></li>
+                </ul>
             </div>
 
             <div class="faq-item">


### PR DESCRIPTION
- Remove outdated AWS verification note from crew registration form
- Replace AWS email FAQ with a personal information handling section with links to NSC, AWS, and Mailjet privacy policies

Closes #80