### PR TITLE
feat: wire crew absence ranking into season update pipeline

### DIFF
--- a/src/Application/Port/Repository/CrewRepositoryInterface.php
+++ b/src/Application/Port/Repository/CrewRepositoryInterface.php
@@ -137,6 +137,14 @@ interface CrewRepositoryInterface
     public function updateRankCommitment(Crew $crew): void;
 
     /**
+     * Update crew absence rank only (without touching other fields)
+     *
+     * @param Crew $crew Crew with updated absence rank
+     * @return void
+     */
+    public function updateRankAbsence(Crew $crew): void;
+
+    /**
      * Get crew count
      *
      * @return int

--- a/src/Application/UseCase/Season/ProcessSeasonUpdateUseCase.php
+++ b/src/Application/UseCase/Season/ProcessSeasonUpdateUseCase.php
@@ -98,6 +98,7 @@ class ProcessSeasonUpdateUseCase
 
         // Sync boat participation history from past flotillas and update absence ranks
         $boatHistoryUpdates = $this->syncBoatHistory($fleet);
+        $crewHistoryUpdates = $this->syncCrewHistory($squad);
 
         $eventsProcessed = 0;
         $flotillasGenerated = 0;
@@ -189,9 +190,19 @@ class ProcessSeasonUpdateUseCase
                 $this->boatRepository->updateHistory($boatKey, $eventId, $participated);
             }
 
-            // Persist updated absence ranks
+            // Persist updated boat absence ranks
             foreach ($fleet->all() as $boat) {
                 $this->boatRepository->updateRankAbsence($boat);
+            }
+
+            // Persist crew history entries (upsert — idempotent)
+            foreach ($crewHistoryUpdates as [$crewKey, $eventId, $boatKey]) {
+                $this->crewRepository->updateHistory($crewKey, $eventId, $boatKey);
+            }
+
+            // Persist updated crew absence ranks
+            foreach ($squad->all() as $crew) {
+                $this->crewRepository->updateRankAbsence($crew);
             }
 
             $this->transactionService->commit();
@@ -583,6 +594,72 @@ class ProcessSeasonUpdateUseCase
         // Recompute absence ranks (only counts events that had a flotilla)
         if (!empty($eventIdsWithFlotilla)) {
             $this->rankingService->updateBoatAbsenceRanks($allBoats, $eventIdsWithFlotilla);
+        }
+
+        return $updates;
+    }
+
+    /**
+     * Sync crew assignment history from stored flotillas for past events.
+     *
+     * For each past event that has a flotilla:
+     *   - Crews in crewed_boats  → assigned boat key
+     *   - Crews in waitlist_crews → '' (registered but not assigned)
+     *   - Unregistered crews      → no entry written
+     *
+     * Updates absence rank on each crew in-memory so selection uses correct ranks.
+     *
+     * @param Squad $squad All crews (mutated in place)
+     * @return array<array{CrewKey, EventId, string}> Pending DB writes
+     */
+    private function syncCrewHistory(Squad $squad): array
+    {
+        $pastEventIds = $this->eventRepository->findPastEvents();
+        if (empty($pastEventIds)) {
+            return [];
+        }
+
+        $allCrews = $squad->all();
+        $updates = [];
+        $eventIdsWithFlotilla = [];
+
+        foreach ($pastEventIds as $eventIdString) {
+            $eventId = EventId::fromString($eventIdString);
+            $flotilla = $this->seasonRepository->getFlotilla($eventId);
+            if ($flotilla === null) {
+                continue; // No flotilla data — skip (don't penalise crews)
+            }
+
+            $eventIdsWithFlotilla[] = $eventIdString;
+
+            // Build map: crew_key => boat_key from flotilla
+            $crewBoatMap = [];
+            foreach ($flotilla['crewed_boats'] as $crewedBoat) {
+                $boatKey = $crewedBoat['boat']['key'];
+                foreach ($crewedBoat['crews'] as $crewData) {
+                    $crewBoatMap[$crewData['key']] = $boatKey;
+                }
+            }
+            // Waitlisted crews → '' (registered, not assigned)
+            foreach ($flotilla['waitlist_crews'] as $crewData) {
+                $crewBoatMap[$crewData['key']] ??= '';
+            }
+
+            // Update in-memory history for real DB crews only
+            foreach ($allCrews as $crew) {
+                $crewKeyStr = $crew->getKey()->toString();
+                if (array_key_exists($crewKeyStr, $crewBoatMap)) {
+                    $boatKey = $crewBoatMap[$crewKeyStr];
+                    $crew->setHistory($eventId, $boatKey);
+                    $updates[] = [$crew->getKey(), $eventId, $boatKey];
+                }
+                // No entry for crews not present in the flotilla (unregistered)
+            }
+        }
+
+        // Recompute absence ranks (only counts events that had a flotilla)
+        if (!empty($eventIdsWithFlotilla)) {
+            $this->rankingService->updateCrewAbsenceRanks($allCrews, $eventIdsWithFlotilla);
         }
 
         return $updates;

--- a/src/Infrastructure/Persistence/SQLite/CrewRepository.php
+++ b/src/Infrastructure/Persistence/SQLite/CrewRepository.php
@@ -251,6 +251,24 @@ class CrewRepository implements CrewRepositoryInterface
         ]);
     }
 
+    public function updateRankAbsence(Crew $crew): void
+    {
+        if ($crew->getId() === null) {
+            return;
+        }
+
+        $rank = $crew->getRank();
+        $stmt = $this->pdo->prepare('
+            UPDATE crews
+            SET rank_absence = :rank_absence
+            WHERE id = :id
+        ');
+        $stmt->execute([
+            'id'           => $crew->getId(),
+            'rank_absence' => $rank->getDimension(CrewRankDimension::ABSENCE),
+        ]);
+    }
+
     public function count(): int
     {
         $stmt = $this->pdo->query('SELECT COUNT(*) FROM crews');

--- a/tests/Integration/Application/UseCase/Season/ProcessSeasonUpdateUseCaseTest.php
+++ b/tests/Integration/Application/UseCase/Season/ProcessSeasonUpdateUseCaseTest.php
@@ -829,6 +829,168 @@ class ProcessSeasonUpdateUseCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Test: crew_history rows are written for past events based on stored flotilla data
+     *
+     * Crews present in crewed_boats get the boat key; waitlisted crews get '';
+     * crews not registered get no entry. rank_absence reflects the count of '' entries.
+     */
+    public function testCrewHistoryWrittenForPastFlotilla(): void
+    {
+        // Arrange: 3 crews, 1 past event, 1 future event
+        $crewAssignedId = $this->createTestCrew('crew-assigned');
+        $crewWaitlistId = $this->createTestCrew('crew-waitlist');
+        $crewAbsentId   = $this->createTestCrew('crew-absent');
+
+        $boatId = $this->createTestBoat('boat-x', 1, 2);
+
+        $this->createPastEvent('Fri Jan 17', '2026-01-17');
+        $this->createTestEvent('Fri May 29', '2026-05-29');
+
+        // Pre-store a flotilla for the past event:
+        // crew-assigned was on boat-x; crew-waitlist was waitlisted; crew-absent had no entry
+        $this->seasonRepository->saveFlotilla(EventId::fromString('Fri Jan 17'), [
+            'event_id' => 'Fri Jan 17',
+            'crewed_boats' => [
+                [
+                    'boat'  => ['key' => 'boat-x', 'display_name' => 'Boat X'],
+                    'crews' => [['key' => 'crew-assigned', 'display_name' => 'Crew crew-assigned']],
+                ],
+            ],
+            'waitlist_boats' => [],
+            'waitlist_crews' => [['key' => 'crew-waitlist', 'display_name' => 'Crew crew-waitlist']],
+        ]);
+
+        // Set availability for the future event so the pipeline has something to process
+        $this->setBoatAvailability($boatId, 'Fri May 29', 2);
+        $this->setCrewAvailability($crewAssignedId, 'Fri May 29', AvailabilityStatus::AVAILABLE->value);
+
+        // Act
+        $this->useCase->execute();
+
+        // Assert: crew_history rows were written for crew-assigned and crew-waitlist
+        $stmt = $this->pdo->prepare('SELECT boat_key FROM crew_history WHERE crew_id = ? AND event_id = ?');
+
+        $stmt->execute([$crewAssignedId, 'Fri Jan 17']);
+        $this->assertEquals('boat-x', $stmt->fetchColumn(), 'crew-assigned should have boat key boat-x');
+
+        $stmt->execute([$crewWaitlistId, 'Fri Jan 17']);
+        $this->assertEquals('', $stmt->fetchColumn(), 'crew-waitlist should have empty string boat key');
+
+        // crew-absent had no flotilla entry — no row should be written
+        $stmt->execute([$crewAbsentId, 'Fri Jan 17']);
+        $this->assertFalse($stmt->fetchColumn(), 'crew-absent should have no crew_history row');
+
+        // Assert: absence ranks persisted to DB
+        $rankAssigned  = (int)$this->pdo->query("SELECT rank_absence FROM crews WHERE id = $crewAssignedId")->fetchColumn();
+        $rankWaitlist  = (int)$this->pdo->query("SELECT rank_absence FROM crews WHERE id = $crewWaitlistId")->fetchColumn();
+
+        $this->assertEquals(0, $rankAssigned, 'crew-assigned was on a boat; absence should be 0');
+        $this->assertEquals(1, $rankWaitlist, 'crew-waitlist was not assigned once; absence should be 1');
+    }
+
+    /**
+     * Test: Crew with higher absence rank is selected over crew with lower absence rank
+     *
+     * After syncing 1 past event where crew-present was assigned and crew-absent was waitlisted,
+     * crew-absent gets rank_absence=1 and crew-present gets rank_absence=0.
+     * With only 1 boat berth available, crew-absent (higher priority) is selected.
+     */
+    public function testAbsentCrewSelectedOverPresentCrew(): void
+    {
+        // Arrange: 1 boat (1 berth), 2 crews, 1 past event, 1 future event
+        // crew-present: in past flotilla crewed_boats → absence=0
+        // crew-absent:  in past flotilla waitlist_crews → absence=1 → higher priority
+        $crewPresentId = $this->createTestCrew('crew-present');
+        $crewAbsentId  = $this->createTestCrew('crew-absent');
+
+        $boatId = $this->createTestBoat('boat-y', 1, 1);
+
+        $this->createPastEvent('Fri Jan 17', '2026-01-17');
+        $this->createTestEvent('Fri May 29', '2026-05-29');
+
+        // Past flotilla: crew-present was on boat-y; crew-absent was waitlisted
+        $this->seasonRepository->saveFlotilla(EventId::fromString('Fri Jan 17'), [
+            'event_id'     => 'Fri Jan 17',
+            'crewed_boats' => [
+                [
+                    'boat'  => ['key' => 'boat-y', 'display_name' => 'Boat Y'],
+                    'crews' => [['key' => 'crew-present', 'display_name' => 'Crew crew-present']],
+                ],
+            ],
+            'waitlist_boats' => [],
+            'waitlist_crews' => [['key' => 'crew-absent', 'display_name' => 'Crew crew-absent']],
+        ]);
+
+        // Both crews available for next event; boat only has 1 berth → 1 crew waitlisted
+        $this->setBoatAvailability($boatId, 'Fri May 29', 1);
+        $this->setCrewAvailability($crewPresentId, 'Fri May 29', AvailabilityStatus::AVAILABLE->value);
+        $this->setCrewAvailability($crewAbsentId, 'Fri May 29', AvailabilityStatus::AVAILABLE->value);
+
+        // Act
+        $this->useCase->execute();
+
+        $flotilla = $this->seasonRepository->getFlotilla(EventId::fromString('Fri May 29'));
+
+        // Assert: 1 crew assigned, 1 crew waitlisted
+        $totalAssigned = 0;
+        foreach ($flotilla['crewed_boats'] as $crewedBoat) {
+            $totalAssigned += count($crewedBoat['crews']);
+        }
+        $this->assertEquals(1, $totalAssigned, 'Exactly 1 crew should be assigned');
+        $this->assertCount(1, $flotilla['waitlist_crews'], 'Exactly 1 crew should be waitlisted');
+
+        // Assert: crew-absent (absence=1 → higher priority) was assigned; crew-present was waitlisted
+        $assignedKey = $flotilla['crewed_boats'][0]['crews'][0]['key'];
+        $this->assertEquals('crew-absent', $assignedKey, 'crew-absent (absence=1) should be selected over crew-present (absence=0)');
+    }
+
+    /**
+     * Test: Crew history sync is idempotent — running the pipeline twice produces identical results
+     */
+    public function testCrewHistorySyncIsIdempotent(): void
+    {
+        // Arrange
+        $crewId = $this->createTestCrew('crew-a');
+        $boatId = $this->createTestBoat('boat-a', 1, 2);
+
+        $this->createPastEvent('Fri Jan 17', '2026-01-17');
+        $this->createTestEvent('Fri May 29', '2026-05-29');
+
+        $this->seasonRepository->saveFlotilla(EventId::fromString('Fri Jan 17'), [
+            'event_id'     => 'Fri Jan 17',
+            'crewed_boats' => [
+                [
+                    'boat'  => ['key' => 'boat-a', 'display_name' => 'Boat boat-a'],
+                    'crews' => [['key' => 'crew-a', 'display_name' => 'Crew crew-a']],
+                ],
+            ],
+            'waitlist_boats' => [],
+            'waitlist_crews' => [],
+        ]);
+
+        $this->setBoatAvailability($boatId, 'Fri May 29', 2);
+        $this->setCrewAvailability($crewId, 'Fri May 29', AvailabilityStatus::AVAILABLE->value);
+
+        // Act: run pipeline twice
+        $this->useCase->execute();
+        $rankAfterFirst = (int)$this->pdo->query("SELECT rank_absence FROM crews WHERE id = $crewId")->fetchColumn();
+        $histStmt = $this->pdo->prepare('SELECT boat_key FROM crew_history WHERE crew_id = ? AND event_id = ?');
+        $histStmt->execute([$crewId, 'Fri Jan 17']);
+        $boatKeyAfterFirst = $histStmt->fetchColumn();
+
+        $this->useCase->execute();
+        $rankAfterSecond = (int)$this->pdo->query("SELECT rank_absence FROM crews WHERE id = $crewId")->fetchColumn();
+        $histStmt->execute([$crewId, 'Fri Jan 17']);
+        $boatKeyAfterSecond = $histStmt->fetchColumn();
+
+        // Assert: same results both times
+        $this->assertEquals($rankAfterFirst, $rankAfterSecond, 'rank_absence should be identical after both runs');
+        $this->assertEquals($boatKeyAfterFirst, $boatKeyAfterSecond, 'crew_history should be identical after both runs');
+        $this->assertEquals('boat-a', $boatKeyAfterFirst, 'crew-a was assigned to boat-a');
+        $this->assertEquals(0, $rankAfterFirst, 'crew-a was assigned; absence should be 0');
+    }
+
+    /**
      * Test: Boat with higher absence rank is selected over boat with lower absence rank
      *
      * After syncing 1 past event where boat-a participated and boat-b was absent,


### PR DESCRIPTION
Mirrors the existing boat-history sync pattern for crews:
- Add `syncCrewHistory()` to collect crew assignments from past flotillas (crewed_boats → boat key, waitlist_crews → '', unregistered → no entry)
- Call `updateCrewAbsenceRanks()` to recompute absence ranks in-memory
- Persist `crew_history` rows and `rank_absence` in the transaction
- Add `CrewRepositoryInterface::updateRankAbsence()` and implement in `CrewRepository`

Adds three integration tests covering history writes, selection ordering, and idempotency.

Partially address #64

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>