### PR TITLE
feat: trigger recalculation on config save and add cron recalculate script

### DIFF
--- a/bin/recalculate.php
+++ b/bin/recalculate.php
@@ -1,0 +1,136 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Cron Recalculation Entry Point
+ *
+ * Runs the season update pipeline (selection + assignment) on event day,
+ * within the 1-hour window after the blackout window closes.
+ * Handles its own timing and idempotency so the cron schedule can run hourly
+ * without producing duplicate runs.
+ *
+ * Usage:
+ *   php bin/recalculate.php
+ *
+ * Cron schedule (hourly):
+ *   0 * * * * /usr/bin/php /opt/bitnami/jaws/bin/recalculate.php >> /opt/bitnami/jaws/logs/cron.log 2>&1
+ */
+
+// Resolve project root regardless of where the script is called from
+$projectRoot = dirname(__DIR__);
+
+// Bootstrap autoloader and environment
+require_once $projectRoot . '/vendor/autoload.php';
+
+// Load .env if it exists (development convenience)
+$envFile = $projectRoot . '/.env';
+if (file_exists($envFile)) {
+    $lines = file($envFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    foreach ($lines as $line) {
+        if (str_starts_with(trim($line), '#') || !str_contains($line, '=')) {
+            continue;
+        }
+        [$name, $value] = explode('=', $line, 2);
+        putenv(trim($name) . '=' . trim($value));
+    }
+}
+
+// Always pin DB_PATH to an absolute path based on the project root.
+// The .env file may contain a relative path that only works from a specific CWD.
+$absoluteDbPath = $projectRoot . '/database/jaws.db';
+putenv('DB_PATH=' . $absoluteDbPath);
+
+use App\Domain\ValueObject\EventId;
+use App\Infrastructure\Persistence\SQLite\Connection;
+
+$timestamp = date('Y-m-d H:i:s');
+echo "[{$timestamp}] recalculate.php\n";
+
+// -----------------------------------------------------------------------
+// Bootstrap DI container (uses production DB)
+// -----------------------------------------------------------------------
+$container = require $projectRoot . '/config/container.php';
+
+// -----------------------------------------------------------------------
+// Find the next upcoming event
+// -----------------------------------------------------------------------
+/** @var \App\Application\Port\Repository\EventRepositoryInterface $eventRepo */
+$eventRepo = $container->get(\App\Application\Port\Repository\EventRepositoryInterface::class);
+
+$nextEventIdString = $eventRepo->findNextEvent();
+
+if ($nextEventIdString === null) {
+    echo "No upcoming events. Exiting.\n";
+    exit(0);
+}
+
+$eventId   = EventId::fromString($nextEventIdString);
+$eventData = $eventRepo->findById($eventId);
+
+if ($eventData === null) {
+    echo "Event data not found for {$nextEventIdString}. Exiting.\n";
+    exit(0);
+}
+
+$eventDate = $eventData['event_date'];  // YYYY-MM-DD
+
+$now = new \DateTimeImmutable('now', new \DateTimeZone(getenv('APP_TIMEZONE') ?: 'America/Toronto'));
+
+// -----------------------------------------------------------------------
+// Timing check — event day only, within [blackout_to, blackout_to + 1h]
+// -----------------------------------------------------------------------
+$todayDate = $now->format('Y-m-d');
+
+if ($todayDate !== $eventDate) {
+    echo "Not event day (today={$todayDate}, event={$eventDate}). Exiting.\n";
+    exit(0);
+}
+
+/** @var \App\Application\Port\Repository\SeasonRepositoryInterface $seasonRepo */
+$seasonRepo  = $container->get(\App\Application\Port\Repository\SeasonRepositoryInterface::class);
+$config      = $seasonRepo->getConfig();
+$blackoutTo  = $config['blackout_to'] ?? '18:00:00';  // HH:MM:SS
+
+$currentTime    = $now->format('H:i:s');
+$windowEnd      = date('H:i:s', strtotime($blackoutTo) + 3600);
+
+if ($currentTime < $blackoutTo || $currentTime > $windowEnd) {
+    echo "Not in recalculation window (now={$currentTime}, window={$blackoutTo}–{$windowEnd}). Exiting.\n";
+    exit(0);
+}
+
+// -----------------------------------------------------------------------
+// Idempotency check — cron_notifications table
+// -----------------------------------------------------------------------
+$pdo = Connection::getInstance();
+
+$checkStmt = $pdo->prepare('SELECT id FROM cron_notifications WHERE event_id = ? AND type = ?');
+$checkStmt->execute([$eventId->toString(), 'recalculate']);
+
+if ($checkStmt->fetch() !== false) {
+    echo "Already ran recalculate for {$eventId->toString()}. Exiting.\n";
+    exit(0);
+}
+
+// -----------------------------------------------------------------------
+// Run season update pipeline
+// -----------------------------------------------------------------------
+/** @var \App\Application\UseCase\Season\ProcessSeasonUpdateUseCase $useCase */
+$useCase = $container->get(\App\Application\UseCase\Season\ProcessSeasonUpdateUseCase::class);
+$result  = $useCase->execute();
+
+$eventsProcessed   = $result['events_processed'] ?? 0;
+$flotillasGenerated = $result['flotillas_generated'] ?? 0;
+
+// -----------------------------------------------------------------------
+// Record notification (INSERT OR IGNORE for race safety)
+// -----------------------------------------------------------------------
+$insertStmt = $pdo->prepare(
+    'INSERT OR IGNORE INTO cron_notifications (event_id, type, recipients_count, skipped_count) VALUES (?, ?, ?, ?)'
+);
+$insertStmt->execute([$eventId->toString(), 'recalculate', $eventsProcessed, 0]);
+
+echo "Done. events_processed={$eventsProcessed} flotillas_generated={$flotillasGenerated}\n";
+exit(0);

--- a/config/container.php
+++ b/config/container.php
@@ -471,6 +471,7 @@ $container->set(\App\Presentation\Controller\AdminController::class, function ($
         $c->get(\App\Application\UseCase\Admin\SendCustomNotificationUseCase::class),
         $c->get(\App\Application\UseCase\Admin\GetConfigUseCase::class),
         $c->get(\App\Application\UseCase\Season\UpdateConfigUseCase::class),
+        $c->get(\App\Application\UseCase\Season\ProcessSeasonUpdateUseCase::class),
         $c->get(\App\Application\UseCase\Admin\GetAllUsersUseCase::class),
         $c->get(\App\Application\UseCase\Admin\SetUserAdminUseCase::class),
         $c->get(\App\Application\UseCase\Admin\GetUserDetailUseCase::class),

--- a/src/Presentation/Controller/AdminController.php
+++ b/src/Presentation/Controller/AdminController.php
@@ -18,6 +18,7 @@ use App\Application\UseCase\Admin\AddToCrewWhitelistUseCase;
 use App\Application\UseCase\Admin\RemoveFromCrewWhitelistUseCase;
 use App\Application\UseCase\Admin\SetCrewCommitmentRankUseCase;
 use App\Application\UseCase\Season\UpdateConfigUseCase;
+use App\Application\UseCase\Season\ProcessSeasonUpdateUseCase;
 use App\Application\DTO\Request\UpdateConfigRequest;
 use App\Application\Exception\BoatNotFoundException;
 use App\Application\Exception\CrewNotFoundException;
@@ -39,6 +40,7 @@ class AdminController
         private SendCustomNotificationUseCase $sendCustomNotificationUseCase,
         private GetConfigUseCase $getConfigUseCase,
         private UpdateConfigUseCase $updateConfigUseCase,
+        private ProcessSeasonUpdateUseCase $processSeasonUpdateUseCase,
         private GetAllUsersUseCase $getAllUsersUseCase,
         private SetUserAdminUseCase $setUserAdminUseCase,
         private GetUserDetailUseCase $getUserDetailUseCase,
@@ -203,7 +205,14 @@ class AdminController
 
             $result = $this->updateConfigUseCase->execute($request);
 
-            return JsonResponse::success($result);
+            $recalculation = [];
+            try {
+                $recalculation = $this->processSeasonUpdateUseCase->execute();
+            } catch (\Exception $e) {
+                $recalculation = ['error' => $e->getMessage()];
+            }
+
+            return JsonResponse::success(array_merge($result, ['recalculation' => $recalculation]));
         } catch (ValidationException $e) {
             return JsonResponse::error($e->getMessage(), 400, $e->getErrors());
         } catch (\Exception $e) {

--- a/tests/Integration/Api/AdminApiTest.php
+++ b/tests/Integration/Api/AdminApiTest.php
@@ -71,6 +71,32 @@ class AdminApiTest extends TestCase
         $this->cleanupTestUser($testData['userId']);
     }
 
+    public function testUpdateConfigResponseIncludesRecalculation(): void
+    {
+        $testData = $this->createTestAdmin($this->baseUrl);
+
+        $response = $this->makeRequest('PATCH', "{$this->baseUrl}/admin/config", [
+            'start_time' => '10:00:00',
+            'finish_time' => '18:00:00',
+        ], [
+            "Authorization: Bearer {$testData['token']}",
+        ]);
+
+        $this->assertEquals(200, $response['status']);
+        $this->assertTrue($response['body']['success']);
+        $this->assertArrayHasKey('recalculation', $response['body']['data']);
+
+        $recalculation = $response['body']['data']['recalculation'];
+        $this->assertArrayHasKey('success', $recalculation);
+        $this->assertArrayHasKey('events_processed', $recalculation);
+        $this->assertArrayHasKey('flotillas_generated', $recalculation);
+        $this->assertIsInt($recalculation['events_processed']);
+        $this->assertIsInt($recalculation['flotillas_generated']);
+
+        // Cleanup
+        $this->cleanupTestUser($testData['userId']);
+    }
+
     public function testUpdateConfigValidation(): void
     {
         $testData = $this->createTestAdmin($this->baseUrl);

--- a/tests/Unit/Presentation/Controller/AdminControllerTest.php
+++ b/tests/Unit/Presentation/Controller/AdminControllerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Presentation\Controller;
+
+use App\Application\Exception\ValidationException;
+use App\Application\UseCase\Admin\AddToCrewWhitelistUseCase;
+use App\Application\UseCase\Admin\GetAllBoatsUseCase;
+use App\Application\UseCase\Admin\GetAllCrewsUseCase;
+use App\Application\UseCase\Admin\GetAllUsersUseCase;
+use App\Application\UseCase\Admin\GetConfigUseCase;
+use App\Application\UseCase\Admin\GetMatchingDataUseCase;
+use App\Application\UseCase\Admin\GetParticipantEmailsUseCase;
+use App\Application\UseCase\Admin\GetUserDetailUseCase;
+use App\Application\UseCase\Admin\RemoveFromCrewWhitelistUseCase;
+use App\Application\UseCase\Admin\SendCustomNotificationUseCase;
+use App\Application\UseCase\Admin\SetCrewCommitmentRankUseCase;
+use App\Application\UseCase\Admin\SetUserAdminUseCase;
+use App\Application\UseCase\Admin\UpdateCrewProfileUseCase;
+use App\Application\UseCase\Season\ProcessSeasonUpdateUseCase;
+use App\Application\UseCase\Season\UpdateConfigUseCase;
+use App\Presentation\Controller\AdminController;
+use App\Presentation\Response\JsonResponse;
+use PHPUnit\Framework\TestCase;
+
+class AdminControllerTest extends TestCase
+{
+    private array $adminAuth = ['is_admin' => true, 'user_id' => 1];
+
+    private function makeController(
+        UpdateConfigUseCase $updateConfigUseCase,
+        ProcessSeasonUpdateUseCase $processSeasonUpdateUseCase,
+    ): AdminController {
+        return new AdminController(
+            $this->createStub(GetMatchingDataUseCase::class),
+            $this->createStub(GetParticipantEmailsUseCase::class),
+            $this->createStub(SendCustomNotificationUseCase::class),
+            $this->createStub(GetConfigUseCase::class),
+            $updateConfigUseCase,
+            $processSeasonUpdateUseCase,
+            $this->createStub(GetAllUsersUseCase::class),
+            $this->createStub(SetUserAdminUseCase::class),
+            $this->createStub(GetUserDetailUseCase::class),
+            $this->createStub(GetAllCrewsUseCase::class),
+            $this->createStub(GetAllBoatsUseCase::class),
+            $this->createStub(UpdateCrewProfileUseCase::class),
+            $this->createStub(AddToCrewWhitelistUseCase::class),
+            $this->createStub(RemoveFromCrewWhitelistUseCase::class),
+            $this->createStub(SetCrewCommitmentRankUseCase::class),
+        );
+    }
+
+    private function getResponseData(JsonResponse $response): array
+    {
+        return (new \ReflectionClass($response))->getProperty('data')->getValue($response);
+    }
+
+    private function getResponseStatusCode(JsonResponse $response): int
+    {
+        return (new \ReflectionClass($response))->getProperty('statusCode')->getValue($response);
+    }
+
+    public function testUpdateConfigCallsProcessSeasonUpdateAndIncludesResultInResponse(): void
+    {
+        $updateConfigUseCase = $this->createMock(UpdateConfigUseCase::class);
+        $updateConfigUseCase->method('execute')
+            ->willReturn(['success' => true, 'message' => 'Season configuration updated successfully']);
+
+        $processSeasonUpdateUseCase = $this->createMock(ProcessSeasonUpdateUseCase::class);
+        $processSeasonUpdateUseCase->expects($this->once())
+            ->method('execute')
+            ->willReturn(['success' => true, 'events_processed' => 3, 'flotillas_generated' => 3]);
+
+        $controller = $this->makeController($updateConfigUseCase, $processSeasonUpdateUseCase);
+        $response   = $controller->updateConfig([], $this->adminAuth);
+
+        $this->assertEquals(200, $this->getResponseStatusCode($response));
+
+        $data = $this->getResponseData($response);
+        $this->assertTrue($data['data']['recalculation']['success']);
+        $this->assertEquals(3, $data['data']['recalculation']['events_processed']);
+        $this->assertEquals(3, $data['data']['recalculation']['flotillas_generated']);
+    }
+
+    public function testUpdateConfigReturns200WithRecalculationErrorWhenProcessSeasonUpdateThrows(): void
+    {
+        $updateConfigUseCase = $this->createMock(UpdateConfigUseCase::class);
+        $updateConfigUseCase->method('execute')
+            ->willReturn(['success' => true, 'message' => 'Season configuration updated successfully']);
+
+        $processSeasonUpdateUseCase = $this->createMock(ProcessSeasonUpdateUseCase::class);
+        $processSeasonUpdateUseCase->method('execute')
+            ->willThrowException(new \RuntimeException('Database locked'));
+
+        $controller = $this->makeController($updateConfigUseCase, $processSeasonUpdateUseCase);
+        $response   = $controller->updateConfig([], $this->adminAuth);
+
+        // Config was saved — must still be 200
+        $this->assertEquals(200, $this->getResponseStatusCode($response));
+
+        $data = $this->getResponseData($response);
+        $this->assertTrue($data['success']);
+        $this->assertEquals('Database locked', $data['data']['recalculation']['error']);
+    }
+
+    public function testUpdateConfigDoesNotCallProcessSeasonUpdateWhenValidationFails(): void
+    {
+        $updateConfigUseCase = $this->createMock(UpdateConfigUseCase::class);
+        $updateConfigUseCase->method('execute')
+            ->willThrowException(new ValidationException(['source' => 'Invalid value']));
+
+        $processSeasonUpdateUseCase = $this->createMock(ProcessSeasonUpdateUseCase::class);
+        $processSeasonUpdateUseCase->expects($this->never())->method('execute');
+
+        $controller = $this->makeController($updateConfigUseCase, $processSeasonUpdateUseCase);
+        $response   = $controller->updateConfig(['source' => 'invalid'], $this->adminAuth);
+
+        $this->assertEquals(400, $this->getResponseStatusCode($response));
+    }
+}


### PR DESCRIPTION
Resolves #86

- `AdminController::updateConfig()` now calls `ProcessSeasonUpdateUseCase` after saving config; recalculation result is merged into the response. Recalculation errors are caught and returned as `recalculation.error` without affecting the 200 status (config was saved successfully).
- `bin/recalculate.php`: new hourly cron script that runs the season update pipeline on event day within `[blackout_to, blackout_to + 1h]`. Uses `cron_notifications` table (type='recalculate') for idempotency.
- Tests: `AdminControllerTest` (3 unit tests) + `AdminApiTest` extension.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>