### PR TITLE
fix: fail fast on missing or weak JWT_SECRET in production

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -27,6 +27,16 @@ foreach ($_ENV as $key => $value) {
 // Load configuration
 $config = require __DIR__ . '/../config/config.php';
 
+// Fail fast if JWT_SECRET is absent or too short in production
+if ($config['app']['env'] === 'production') {
+    $jwtSecret = getenv('JWT_SECRET');
+    if ($jwtSecret === false || $jwtSecret === '' || strlen($jwtSecret) < 32) {
+        throw new RuntimeException(
+            'JWT_SECRET environment variable must be set to at least 32 characters in production.'
+        );
+    }
+}
+
 // Set timezone
 date_default_timezone_set($config['app']['timezone']);
 

--- a/src/Infrastructure/Service/JwtTokenService.php
+++ b/src/Infrastructure/Service/JwtTokenService.php
@@ -26,18 +26,13 @@ class JwtTokenService implements TokenServiceInterface
     private int $expirationMinutes;
 
     /**
-     * @param string|null $secret Secret key for signing tokens (from env or default)
+     * @param string $secret Secret key for signing tokens
      * @param int $expirationMinutes Token expiration time in minutes
      */
-    public function __construct(?string $secret = null, int $expirationMinutes = 60)
+    public function __construct(string $secret, int $expirationMinutes = 60)
     {
-        $this->secret = $secret ?? getenv('JWT_SECRET') ?: 'CHANGE_THIS_SECRET_IN_PRODUCTION';
+        $this->secret = $secret;
         $this->expirationMinutes = $expirationMinutes;
-
-        // Warn if using default secret in production
-        if ($this->secret === 'CHANGE_THIS_SECRET_IN_PRODUCTION' && getenv('APP_ENV') === 'production') {
-            error_log('WARNING: Using default JWT secret in production. Set JWT_SECRET environment variable.');
-        }
     }
 
     /**

--- a/tests/Integration/Application/UseCase/Auth/LoginUseCaseTest.php
+++ b/tests/Integration/Application/UseCase/Auth/LoginUseCaseTest.php
@@ -32,7 +32,7 @@ class LoginUseCaseTest extends IntegrationTestCase
 
         $this->userRepository = new UserRepository();
         $this->passwordService = new PhpPasswordService();
-        $tokenService = new JwtTokenService();
+        $tokenService = new JwtTokenService('test-secret-key-for-integration-tests');
 
         $this->useCase = new LoginUseCase(
             $this->userRepository,

--- a/tests/Integration/Application/UseCase/Auth/RegisterUseCaseTest.php
+++ b/tests/Integration/Application/UseCase/Auth/RegisterUseCaseTest.php
@@ -47,7 +47,7 @@ class RegisterUseCaseTest extends IntegrationTestCase
         $this->crewRepository = new CrewRepository();
         $this->boatRepository = new BoatRepository();
         $this->passwordService = new PhpPasswordService();
-        $tokenService = new JwtTokenService();
+        $tokenService = new JwtTokenService('test-secret-key-for-integration-tests');
 
         // We need RankingService for the usecase
         $rankingService = new \App\Domain\Service\RankingService();


### PR DESCRIPTION
Add a startup guard in `public/index.php` that throws a`RuntimeException` if `JWT_SECRET` is absent or under 32 characters when `APP_ENV=production`. Remove the internal fallback chain in `JwtTokenService` (dead code — secret is always injected via container) and tighten the constructor to require a non-nullable string. Update two integration tests to pass an explicit test secret.

Resolves #108 