### PR TITLE
fix: handle missing mailjet credentials and misleading sent log

### DIFF
--- a/src/Application/UseCase/Auth/ForgotPasswordUseCase.php
+++ b/src/Application/UseCase/Auth/ForgotPasswordUseCase.php
@@ -71,6 +71,9 @@ class ForgotPasswordUseCase
                 subject: 'Reset your password',
                 body: $body,
             );
+            $this->logger->info('auth.forgot_password.sent', [
+                'user_id' => $user->getId(),
+            ]);
         } catch (\Throwable $e) {
             // Non-fatal: log but do not surface the error to the caller
             $this->logger->error('auth.forgot_password.email_failed', [
@@ -78,9 +81,5 @@ class ForgotPasswordUseCase
                 'error'   => $e->getMessage(),
             ]);
         }
-
-        $this->logger->info('auth.forgot_password.sent', [
-            'user_id' => $user->getId(),
-        ]);
     }
 }

--- a/src/Infrastructure/Service/MailjetEmailService.php
+++ b/src/Infrastructure/Service/MailjetEmailService.php
@@ -162,6 +162,13 @@ class MailjetEmailService implements EmailServiceInterface
 
     private function postMessage(array $message): bool
     {
+        if ($this->apiKey === '' || $this->apiSecret === '') {
+            $this->logger->error('email.credentials_missing', [
+                'message' => 'Mailjet API key or secret is empty',
+            ]);
+            return false;
+        }
+
         $mj    = $this->newMailjetClient();
         $delay = self::RETRY_BASE_DELAY;
 

--- a/tests/Unit/Application/UseCase/Auth/ForgotPasswordUseCaseTest.php
+++ b/tests/Unit/Application/UseCase/Auth/ForgotPasswordUseCaseTest.php
@@ -13,6 +13,7 @@ use App\Application\Port\Service\EmailTemplateServiceInterface;
 use App\Application\UseCase\Auth\ForgotPasswordUseCase;
 use App\Domain\Entity\User;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 class ForgotPasswordUseCaseTest extends TestCase
@@ -189,6 +190,34 @@ class ForgotPasswordUseCaseTest extends TestCase
         $this->useCase->execute(new ForgotPasswordRequest('user@example.com'));
 
         $this->addToAssertionCount(1);
+    }
+
+    public function testDoesNotLogSentWhenEmailFails(): void
+    {
+        $user = $this->makeUser(1, 'user@example.com');
+        $this->userRepository->method('findByEmail')->willReturn($user);
+
+        $this->emailService->method('send')
+            ->willThrowException(new \RuntimeException('SMTP unavailable'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with('auth.forgot_password.email_failed', $this->anything());
+        $logger->expects($this->never())
+            ->method('info')
+            ->with('auth.forgot_password.sent', $this->anything());
+
+        $useCase = new ForgotPasswordUseCase(
+            $this->userRepository,
+            $this->tokenRepository,
+            $this->emailService,
+            $this->emailTemplateService,
+            $this->config,
+            $logger,
+        );
+
+        $useCase->execute(new ForgotPasswordRequest('user@example.com'));
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Unit/Infrastructure/Service/MailjetEmailServiceTest.php
+++ b/tests/Unit/Infrastructure/Service/MailjetEmailServiceTest.php
@@ -8,6 +8,7 @@ use App\Infrastructure\Service\MailjetEmailService;
 use Mailjet\Client;
 use Mailjet\Response;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 /**
  * Unit tests for MailjetEmailService.
@@ -321,5 +322,29 @@ class MailjetEmailServiceTest extends TestCase
 
         $this->assertSame('from@test.com', $state->messages[0]['From']['Email']);
         $this->assertSame('Test Sender',   $state->messages[0]['From']['Name']);
+    }
+
+    // ── Group 8: Credential validation ────────────────────────────────────────
+
+    public function testSendReturnsFalseWhenApiKeyIsEmpty(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with('email.credentials_missing', $this->anything());
+
+        $svc = new MailjetEmailService('', 'secret', 'from@test.com', 'Test', $logger);
+        $this->assertFalse($svc->send('to@example.com', 'Sub', 'Body'));
+    }
+
+    public function testSendReturnsFalseWhenApiSecretIsEmpty(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with('email.credentials_missing', $this->anything());
+
+        $svc = new MailjetEmailService('key', '', 'from@test.com', 'Test', $logger);
+        $this->assertFalse($svc->send('to@example.com', 'Sub', 'Body'));
     }
 }


### PR DESCRIPTION
Empty API credentials caused an opaque Mailjet SDK error during password reset. Add early credential validation in `MailjetEmailService` and move the "sent" log inside the try block so it only fires on successful email delivery.

Closes #125