### PR TITLE
 feat: add account suspension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,7 @@ For each rule: find highest-loss crew → find best-grad swap → swap if improv
 | GET | /api/admin/users | AdminController::getUsers |
 | GET | /api/admin/users/{userId} | AdminController::getUser |
 | PATCH | /api/admin/users/{userId}/admin | AdminController::setUserAdmin |
+| PATCH | /api/admin/users/{userId}/status | AdminController::setUserStatus |
 | GET | /api/admin/crews | AdminController::getAllCrews |
 | PATCH | /api/admin/crews/{crewKey} | AdminController::updateCrewProfile |
 | POST | /api/admin/crews/{crewKey}/whitelist/{boatKey} | AdminController::addToWhitelist |

--- a/config/container.php
+++ b/config/container.php
@@ -350,6 +350,14 @@ $container->set(\App\Application\UseCase\Admin\SetUserAdminUseCase::class, funct
     );
 });
 
+$container->set(\App\Application\UseCase\Admin\SetUserStatusUseCase::class, function ($c) {
+    return new \App\Application\UseCase\Admin\SetUserStatusUseCase(
+        $c->get(UserRepositoryInterface::class),
+        $c->get(\App\Application\UseCase\Season\ProcessSeasonUpdateUseCase::class),
+        $c->get(LoggerInterface::class)
+    );
+});
+
 $container->set(\App\Application\UseCase\Admin\GetUserDetailUseCase::class, function ($c) {
     return new \App\Application\UseCase\Admin\GetUserDetailUseCase(
         $c->get(UserRepositoryInterface::class),
@@ -553,6 +561,7 @@ $container->set(\App\Presentation\Controller\AdminController::class, function ($
         $c->get(\App\Application\UseCase\Season\ProcessSeasonUpdateUseCase::class),
         $c->get(\App\Application\UseCase\Admin\GetAllUsersUseCase::class),
         $c->get(\App\Application\UseCase\Admin\SetUserAdminUseCase::class),
+        $c->get(\App\Application\UseCase\Admin\SetUserStatusUseCase::class),
         $c->get(\App\Application\UseCase\Admin\GetUserDetailUseCase::class),
         $c->get(\App\Application\UseCase\Admin\GetAllCrewsUseCase::class),
         $c->get(\App\Application\UseCase\Admin\GetAllBoatsUseCase::class),
@@ -588,7 +597,8 @@ $container->set(\App\Presentation\Controller\UserController::class, function ($c
 
 $container->set(\App\Presentation\Middleware\JwtAuthMiddleware::class, function ($c) {
     return new \App\Presentation\Middleware\JwtAuthMiddleware(
-        $c->get(TokenServiceInterface::class)
+        $c->get(TokenServiceInterface::class),
+        $c->get(UserRepositoryInterface::class)
     );
 });
 

--- a/config/routes.php
+++ b/config/routes.php
@@ -240,6 +240,15 @@ return [
         'auth' => true,
     ],
 
+    // Set User Account Status (suspend / reactivate)
+    [
+        'method' => 'PATCH',
+        'path' => '/api/admin/users/{userId}/status',
+        'controller' => AdminController::class,
+        'action' => 'setUserStatus',
+        'auth' => true,
+    ],
+
     // Get Single User Detail (with crew profile)
     [
         'method' => 'GET',

--- a/database/migrations/20260614000000_add_user_disabled_at.php
+++ b/database/migrations/20260614000000_add_user_disabled_at.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Add Disabled At Column Migration
+ *
+ * Adds a nullable disabled_at timestamp to the users table to support
+ * reversible account suspension (deactivate / reactivate) by admins.
+ *
+ * Semantics:
+ * - disabled_at IS NULL  => account is active
+ * - disabled_at NOT NULL => account is suspended (login blocked, existing
+ *   tokens rejected, linked crew/boat excluded from selection & flotillas)
+ *
+ * A suspended account is fully reversible: clearing disabled_at restores it.
+ * Accounts are still permanently removed via the end-of-season reset.
+ */
+final class AddUserDisabledAt extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('users')
+             ->addColumn('disabled_at', 'datetime', [
+                 'null' => true,
+                 'after' => 'last_logout',
+             ])
+             ->update();
+    }
+}

--- a/public/app/admin-user-edit.html
+++ b/public/app/admin-user-edit.html
@@ -95,6 +95,21 @@
                 </div>
             </div>
 
+            <!-- Account Status -->
+            <div id="section-account-status" class="form-section" style="display:none;">
+                <h2>Account Status</h2>
+                <div class="field-group">
+                    <p>Current status: <strong id="status-current"></strong></p>
+                    <p class="help-text">
+                        Deactivating an account blocks sign-in immediately, signs the user out of
+                        any active session, and removes their boat or crew from upcoming flotillas.
+                        It is fully reversible and preserves all history. You cannot deactivate your
+                        own account.
+                    </p>
+                    <button id="status-toggle-btn" class="btn btn-danger">Deactivate Account</button>
+                </div>
+            </div>
+
             <!-- Skill Level (crew only) -->
             <div id="section-skill" class="form-section" style="display:none;">
                 <h2>Skill Level</h2>

--- a/public/app/css/styles.css
+++ b/public/app/css/styles.css
@@ -1276,6 +1276,19 @@ nav .user-greeting {
   box-shadow: 0 2px 8px rgba(108, 92, 231, 0.3);
 }
 
+/* Deactivated account indicators */
+.user-badge.disabled {
+  background: #6c757d;
+  box-shadow: none;
+  margin-top: 0;
+  padding: 0.3rem 0.9rem;
+  font-size: 0.8rem;
+}
+
+.user-row-disabled td {
+  opacity: 0.6;
+}
+
 /* Admin Actions Grid */
 .admin-actions {
   display: grid;

--- a/public/app/js/adminService.js
+++ b/public/app/js/adminService.js
@@ -129,6 +129,27 @@ export async function setUserAdmin(userId, isAdmin) {
 }
 
 /**
+ * Suspend (disable) or reactivate a user account
+ * @param {number} userId - Target user ID
+ * @param {boolean} disabled - Whether to suspend (true) or reactivate (false)
+ * @returns {Promise<Object>} Updated user summary
+ */
+export async function setUserStatus(userId, disabled) {
+    try {
+        const response = await apiService.patch(API_CONFIG.ENDPOINTS.ADMIN_USER_STATUS, { disabled }, { id: userId });
+
+        if (!response.success) {
+            throw new Error(response.message || 'Failed to update account status');
+        }
+
+        return response.data;
+    } catch (error) {
+        console.error('AdminService: Failed to set user status:', error);
+        throw error;
+    }
+}
+
+/**
  * Get a single user's detail including linked crew profile
  * @param {number} userId - Target user ID
  * @returns {Promise<{user: Object, crew: Object|null}>}

--- a/public/app/js/config.js
+++ b/public/app/js/config.js
@@ -39,6 +39,7 @@ export const API_CONFIG = {
         ADMIN_CONFIG: '/admin/config',
         ADMIN_USERS: '/admin/users',
         ADMIN_USER_ADMIN: '/admin/users/:id/admin',
+        ADMIN_USER_STATUS: '/admin/users/:id/status',
         ADMIN_USER_DETAIL: '/admin/users/:userId',
         ADMIN_CREWS: '/admin/crews',
         ADMIN_BOATS: '/admin/boats',

--- a/public/app/js/pages/admin-user-edit-page.js
+++ b/public/app/js/pages/admin-user-edit-page.js
@@ -93,6 +93,7 @@ function renderPage() {
 
     renderUserInfo(user);
     renderAdminRights(user);
+    renderAccountStatus(user);
 
     if (crew) {
         renderSkill(crew);
@@ -153,6 +154,82 @@ async function handleAdminSave(toggle) {
         showToast(error.message || 'Failed to update admin status', 'error');
         // Revert toggle
         toggle.checked = targetUserData.user.is_admin;
+    } finally {
+        btn.disabled = false;
+    }
+}
+
+// ==================== Account Status ====================
+
+function renderAccountStatus(user) {
+    const section = document.getElementById('section-account-status');
+    const btn = document.getElementById('status-toggle-btn');
+
+    updateAccountStatusView(user);
+
+    // Cannot deactivate your own account
+    if (user.id === currentUser.id) {
+        btn.disabled = true;
+        btn.title = 'You cannot deactivate your own account';
+    } else {
+        btn.addEventListener('click', handleStatusToggle);
+    }
+
+    section.style.display = '';
+}
+
+/**
+ * Reflect the current disabled state in the status label and toggle button
+ */
+function updateAccountStatusView(user) {
+    const label = document.getElementById('status-current');
+    const btn = document.getElementById('status-toggle-btn');
+
+    if (user.disabled) {
+        const when = user.disabled_at
+            ? ` (since ${new Date(user.disabled_at).toLocaleDateString()})`
+            : '';
+        label.textContent = `Deactivated${when}`;
+        btn.textContent = 'Reactivate Account';
+        btn.classList.remove('btn-danger');
+        btn.classList.add('btn-primary');
+    } else {
+        label.textContent = 'Active';
+        btn.textContent = 'Deactivate Account';
+        btn.classList.remove('btn-primary');
+        btn.classList.add('btn-danger');
+    }
+}
+
+async function handleStatusToggle() {
+    const btn = document.getElementById('status-toggle-btn');
+    const currentlyDisabled = targetUserData.user.disabled === true;
+    const willDisable = !currentlyDisabled;
+
+    // Confirm the heavier (deactivation) action; reactivation is low-risk
+    if (willDisable && !window.confirm(
+        'Deactivate this account? The user will be signed out and blocked from ' +
+        'signing in, and their boat/crew will be removed from upcoming flotillas. ' +
+        'You can reactivate the account later.'
+    )) {
+        return;
+    }
+
+    btn.disabled = true;
+
+    try {
+        await adminService.setUserStatus(targetUserId, willDisable);
+        // Refresh user data so the label and button reflect the new state
+        const detail = await adminService.getUserDetail(targetUserId);
+        targetUserData = detail;
+        updateAccountStatusView(detail.user);
+        showToast(
+            willDisable ? 'Account deactivated.' : 'Account reactivated.',
+            'success'
+        );
+    } catch (error) {
+        console.error('Failed to update account status:', error);
+        showToast(error.message || 'Failed to update account status', 'error');
     } finally {
         btn.disabled = false;
     }

--- a/public/app/js/pages/admin-users-page.js
+++ b/public/app/js/pages/admin-users-page.js
@@ -89,10 +89,11 @@ function renderUserRow(user) {
         ? '<span class="user-badge boat-owner">⛵ Boat Owner</span>'
         : '<span class="user-badge">🌊 Crew Member</span>';
     const adminBadge = user.is_admin ? ' <span class="admin-badge">Admin</span>' : '';
+    const disabledBadge = user.disabled ? ' <span class="user-badge disabled">Deactivated</span>' : '';
 
     return `
-        <tr>
-            <td>${escapeHtml(user.email)}${adminBadge}</td>
+        <tr class="${user.disabled ? 'user-row-disabled' : ''}">
+            <td>${escapeHtml(user.email)}${adminBadge}${disabledBadge}</td>
             <td>${accountBadge}</td>
             <td><a href="admin-user-edit.html?userId=${user.id}" class="btn btn-sm btn-secondary">Edit</a></td>
         </tr>

--- a/src/Application/Exception/AccountDisabledException.php
+++ b/src/Application/Exception/AccountDisabledException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Exception;
+
+/**
+ * Account Disabled Exception
+ *
+ * Thrown when a suspended (disabled) user attempts to authenticate or use an
+ * existing token. Maps to HTTP 403 Forbidden response.
+ */
+class AccountDisabledException extends \RuntimeException
+{
+    public function __construct(string $message = 'This account has been deactivated. Please contact an administrator.')
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Application/UseCase/Admin/GetAllUsersUseCase.php
+++ b/src/Application/UseCase/Admin/GetAllUsersUseCase.php
@@ -33,6 +33,8 @@ class GetAllUsersUseCase
             'email'        => $user->getEmail(),
             'account_type' => $user->getAccountType(),
             'is_admin'     => $user->isAdmin(),
+            'disabled'     => $user->isDisabled(),
+            'disabled_at'  => $user->getDisabledAt()?->format('Y-m-d H:i:s'),
             'created_at'   => $user->getCreatedAt()->format('Y-m-d H:i:s'),
         ], $users);
     }

--- a/src/Application/UseCase/Admin/GetUserDetailUseCase.php
+++ b/src/Application/UseCase/Admin/GetUserDetailUseCase.php
@@ -43,6 +43,8 @@ class GetUserDetailUseCase
                 'email'        => $user->getEmail(),
                 'account_type' => $user->getAccountType(),
                 'is_admin'     => $user->isAdmin(),
+                'disabled'     => $user->isDisabled(),
+                'disabled_at'  => $user->getDisabledAt()?->format('Y-m-d H:i:s'),
                 'created_at'   => $user->getCreatedAt()->format('Y-m-d H:i:s'),
             ],
             'crew' => $crew ? [

--- a/src/Application/UseCase/Admin/SetUserStatusUseCase.php
+++ b/src/Application/UseCase/Admin/SetUserStatusUseCase.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\UseCase\Admin;
+
+use App\Application\Exception\ValidationException;
+use App\Application\Port\Repository\UserRepositoryInterface;
+use App\Application\UseCase\Season\ProcessSeasonUpdateUseCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Set User Status Use Case
+ *
+ * Suspends (disables) or reactivates a user account. Suspension is reversible:
+ * a disabled account is blocked from logging in, has existing tokens rejected,
+ * and its linked crew/boat is excluded from selection and flotillas — but all
+ * data is preserved and the account can be reactivated at any time.
+ *
+ * Prevents admins from deactivating their own account.
+ *
+ * After the change, the season pipeline is re-run so flotillas re-balance with
+ * the account excluded (on disable) or re-included (on reactivate).
+ */
+class SetUserStatusUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $userRepository,
+        private ProcessSeasonUpdateUseCase $processSeasonUpdateUseCase,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Execute the use case
+     *
+     * @param int  $targetUserId     ID of the user to update
+     * @param bool $disabled         True to suspend, false to reactivate
+     * @param int  $requestingUserId ID of the admin making the change
+     * @return array Updated user summary plus the season recalculation result
+     * @throws ValidationException If an admin tries to deactivate their own account
+     * @throws \RuntimeException   If the target user is not found
+     */
+    public function execute(int $targetUserId, bool $disabled, int $requestingUserId): array
+    {
+        if ($targetUserId === $requestingUserId) {
+            throw new ValidationException(['user_id' => 'You cannot change your own account status']);
+        }
+
+        $user = $this->userRepository->findById($targetUserId);
+
+        if ($user === null) {
+            throw new \RuntimeException("User with ID {$targetUserId} not found");
+        }
+
+        if ($disabled) {
+            $user->disable(new \DateTimeImmutable());
+        } else {
+            $user->reactivate();
+        }
+
+        $this->userRepository->save($user);
+
+        $this->logger->info('admin.user_status_set', [
+            'user_id'            => $targetUserId,
+            'email'              => $user->getEmail(),
+            'disabled'           => $user->isDisabled(),
+            'changed_by_user_id' => $requestingUserId,
+        ]);
+
+        // Re-run the season pipeline so flotillas reflect the change immediately.
+        $recalculation = [];
+        try {
+            $recalculation = $this->processSeasonUpdateUseCase->execute();
+        } catch (\Exception $e) {
+            $recalculation = ['error' => $e->getMessage()];
+        }
+
+        return [
+            'id'           => $user->getId(),
+            'email'        => $user->getEmail(),
+            'account_type' => $user->getAccountType(),
+            'is_admin'     => $user->isAdmin(),
+            'disabled'     => $user->isDisabled(),
+            'disabled_at'  => $user->getDisabledAt()?->format('Y-m-d H:i:s'),
+            'recalculation' => $recalculation,
+        ];
+    }
+}

--- a/src/Application/UseCase/Auth/LoginUseCase.php
+++ b/src/Application/UseCase/Auth/LoginUseCase.php
@@ -7,6 +7,7 @@ namespace App\Application\UseCase\Auth;
 use App\Application\DTO\Request\LoginRequest;
 use App\Application\DTO\Response\AuthResponse;
 use App\Application\DTO\Response\UserResponse;
+use App\Application\Exception\AccountDisabledException;
 use App\Application\Exception\InvalidCredentialsException;
 use App\Application\Exception\ValidationException;
 use App\Application\Port\Repository\UserRepositoryInterface;
@@ -37,6 +38,7 @@ class LoginUseCase
      * @return AuthResponse Authentication response with token
      * @throws ValidationException If validation fails
      * @throws InvalidCredentialsException If credentials are invalid
+     * @throws AccountDisabledException If the account has been suspended
      */
     public function execute(LoginRequest $request): AuthResponse
     {
@@ -55,6 +57,16 @@ class LoginUseCase
         // Verify password
         if (!$this->passwordService->verify($request->password, $user->getPasswordHash())) {
             throw new InvalidCredentialsException();
+        }
+
+        // Block suspended (disabled) accounts. Checked after password
+        // verification so disabled status is not leaked to anonymous callers.
+        if ($user->isDisabled()) {
+            $this->logger->warning('auth.login_disabled', [
+                'user_id' => $user->getId(),
+                'email'   => $user->getEmail(),
+            ]);
+            throw new AccountDisabledException();
         }
 
         // Update last login

--- a/src/Domain/Entity/User.php
+++ b/src/Domain/Entity/User.php
@@ -26,6 +26,7 @@ class User
         private ?\DateTimeImmutable $lastLogout = null,
         private ?\DateTimeImmutable $createdAt = null,
         private ?\DateTimeImmutable $updatedAt = null,
+        private ?\DateTimeImmutable $disabledAt = null,
     ) {
         $this->validateEmail($email);
         $this->validateAccountType($accountType);
@@ -181,6 +182,49 @@ class User
     }
 
     /**
+     * Get the timestamp the account was disabled (null if active)
+     */
+    public function getDisabledAt(): ?\DateTimeImmutable
+    {
+        return $this->disabledAt;
+    }
+
+    /**
+     * Check if the account is currently disabled (suspended)
+     */
+    public function isDisabled(): bool
+    {
+        return $this->disabledAt !== null;
+    }
+
+    /**
+     * Disable (suspend) the account
+     *
+     * Idempotent: re-disabling an already-disabled account preserves the
+     * original disabled_at timestamp.
+     */
+    public function disable(\DateTimeImmutable $time): void
+    {
+        if ($this->disabledAt !== null) {
+            return;
+        }
+        $this->disabledAt = $time;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    /**
+     * Reactivate (un-suspend) the account
+     */
+    public function reactivate(): void
+    {
+        if ($this->disabledAt === null) {
+            return;
+        }
+        $this->disabledAt = null;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    /**
      * Get created at timestamp
      */
     public function getCreatedAt(): \DateTimeImmutable
@@ -208,6 +252,7 @@ class User
             'is_admin' => $this->isAdmin,
             'last_login' => $this->lastLogin?->format('Y-m-d H:i:s'),
             'last_logout' => $this->lastLogout?->format('Y-m-d H:i:s'),
+            'disabled_at' => $this->disabledAt?->format('Y-m-d H:i:s'),
             'created_at' => $this->createdAt->format('Y-m-d H:i:s'),
             'updated_at' => $this->updatedAt->format('Y-m-d H:i:s'),
         ];

--- a/src/Infrastructure/Persistence/SQLite/BoatRepository.php
+++ b/src/Infrastructure/Persistence/SQLite/BoatRepository.php
@@ -79,7 +79,14 @@ class BoatRepository implements BoatRepositoryInterface
 
     public function findAll(): array
     {
-        $stmt = $this->pdo->query('SELECT * FROM boats ORDER BY display_name');
+        // Exclude boats whose linked owner account is disabled (suspended).
+        // Boats with no linked owner (owner_user_id IS NULL) remain visible.
+        $stmt = $this->pdo->query('
+            SELECT b.* FROM boats b
+            LEFT JOIN users u ON b.owner_user_id = u.id
+            WHERE u.disabled_at IS NULL
+            ORDER BY b.display_name
+        ');
         $rows = $stmt->fetchAll();
 
         if (empty($rows)) {
@@ -110,7 +117,9 @@ class BoatRepository implements BoatRepositoryInterface
         $stmt = $this->pdo->prepare('
             SELECT b.* FROM boats b
             INNER JOIN boat_availability ba ON b.id = ba.boat_id
+            LEFT JOIN users u ON b.owner_user_id = u.id
             WHERE ba.event_id = :event_id AND ba.berths > 0
+              AND u.disabled_at IS NULL
             ORDER BY b.display_name
         ');
         $stmt->execute(['event_id' => $eventId->toString()]);

--- a/src/Infrastructure/Persistence/SQLite/CrewRepository.php
+++ b/src/Infrastructure/Persistence/SQLite/CrewRepository.php
@@ -82,7 +82,14 @@ class CrewRepository implements CrewRepositoryInterface
 
     public function findAll(): array
     {
-        $stmt = $this->pdo->query('SELECT * FROM crews ORDER BY display_name');
+        // Exclude crews whose linked user account is disabled (suspended).
+        // Crews with no linked user (user_id IS NULL) remain visible.
+        $stmt = $this->pdo->query('
+            SELECT c.* FROM crews c
+            LEFT JOIN users u ON c.user_id = u.id
+            WHERE u.disabled_at IS NULL
+            ORDER BY c.display_name
+        ');
         $rows = $stmt->fetchAll();
 
         if (empty($rows)) {
@@ -115,7 +122,9 @@ class CrewRepository implements CrewRepositoryInterface
         $stmt = $this->pdo->prepare('
             SELECT c.* FROM crews c
             INNER JOIN crew_availability ca ON c.id = ca.crew_id
+            LEFT JOIN users u ON c.user_id = u.id
             WHERE ca.event_id = :event_id AND ca.status IN (1, 2)
+              AND u.disabled_at IS NULL
             ORDER BY c.display_name
         ');
         $stmt->execute(['event_id' => $eventId->toString()]);
@@ -129,7 +138,9 @@ class CrewRepository implements CrewRepositoryInterface
         $stmt = $this->pdo->prepare('
             SELECT c.* FROM crews c
             INNER JOIN crew_availability ca ON c.id = ca.crew_id
+            LEFT JOIN users u ON c.user_id = u.id
             WHERE ca.event_id = :event_id AND ca.status = 2
+              AND u.disabled_at IS NULL
             ORDER BY c.display_name
         ');
         $stmt->execute(['event_id' => $eventId->toString()]);

--- a/src/Infrastructure/Persistence/SQLite/UserRepository.php
+++ b/src/Infrastructure/Persistence/SQLite/UserRepository.php
@@ -147,8 +147,8 @@ class UserRepository implements UserRepositoryInterface
     private function insert(User $user): void
     {
         $stmt = $this->pdo->prepare('
-            INSERT INTO users (email, password_hash, account_type, is_admin, last_login, last_logout, created_at, updated_at)
-            VALUES (:email, :password_hash, :account_type, :is_admin, :last_login, :last_logout, :created_at, :updated_at)
+            INSERT INTO users (email, password_hash, account_type, is_admin, last_login, last_logout, disabled_at, created_at, updated_at)
+            VALUES (:email, :password_hash, :account_type, :is_admin, :last_login, :last_logout, :disabled_at, :created_at, :updated_at)
         ');
 
         $stmt->execute([
@@ -158,6 +158,7 @@ class UserRepository implements UserRepositoryInterface
             'is_admin' => $user->isAdmin() ? 1 : 0,
             'last_login' => $user->getLastLogin()?->format('Y-m-d H:i:s'),
             'last_logout' => $user->getLastLogout()?->format('Y-m-d H:i:s'),
+            'disabled_at' => $user->getDisabledAt()?->format('Y-m-d H:i:s'),
             'created_at' => $user->getCreatedAt()->format('Y-m-d H:i:s'),
             'updated_at' => $user->getUpdatedAt()->format('Y-m-d H:i:s'),
         ]);
@@ -182,6 +183,7 @@ class UserRepository implements UserRepositoryInterface
                 is_admin = :is_admin,
                 last_login = :last_login,
                 last_logout = :last_logout,
+                disabled_at = :disabled_at,
                 updated_at = :updated_at
             WHERE id = :id
         ');
@@ -194,6 +196,7 @@ class UserRepository implements UserRepositoryInterface
             'is_admin' => $user->isAdmin() ? 1 : 0,
             'last_login' => $user->getLastLogin()?->format('Y-m-d H:i:s'),
             'last_logout' => $user->getLastLogout()?->format('Y-m-d H:i:s'),
+            'disabled_at' => $user->getDisabledAt()?->format('Y-m-d H:i:s'),
             'updated_at' => $user->getUpdatedAt()->format('Y-m-d H:i:s'),
         ]);
     }
@@ -215,6 +218,7 @@ class UserRepository implements UserRepositoryInterface
             lastLogout: $row['last_logout'] ? new \DateTimeImmutable($row['last_logout']) : null,
             createdAt: new \DateTimeImmutable($row['created_at']),
             updatedAt: new \DateTimeImmutable($row['updated_at']),
+            disabledAt: !empty($row['disabled_at']) ? new \DateTimeImmutable($row['disabled_at']) : null,
         );
 
         $user->setId((int)$row['id']);

--- a/src/Presentation/Controller/AdminController.php
+++ b/src/Presentation/Controller/AdminController.php
@@ -10,6 +10,7 @@ use App\Application\UseCase\Admin\SendCustomNotificationUseCase;
 use App\Application\UseCase\Admin\GetConfigUseCase;
 use App\Application\UseCase\Admin\GetAllUsersUseCase;
 use App\Application\UseCase\Admin\SetUserAdminUseCase;
+use App\Application\UseCase\Admin\SetUserStatusUseCase;
 use App\Application\UseCase\Admin\GetUserDetailUseCase;
 use App\Application\UseCase\Admin\GetAllCrewsUseCase;
 use App\Application\UseCase\Admin\GetAllBoatsUseCase;
@@ -42,6 +43,7 @@ class AdminController
         private ProcessSeasonUpdateUseCase $processSeasonUpdateUseCase,
         private GetAllUsersUseCase $getAllUsersUseCase,
         private SetUserAdminUseCase $setUserAdminUseCase,
+        private SetUserStatusUseCase $setUserStatusUseCase,
         private GetUserDetailUseCase $getUserDetailUseCase,
         private GetAllCrewsUseCase $getAllCrewsUseCase,
         private GetAllBoatsUseCase $getAllBoatsUseCase,
@@ -259,6 +261,42 @@ class AdminController
             $requestingUserId = (int)$auth['user_id'];
 
             $result = $this->setUserAdminUseCase->execute($targetUserId, $isAdmin, $requestingUserId);
+
+            return JsonResponse::success($result);
+        } catch (ValidationException $e) {
+            return JsonResponse::error($e->getMessage(), 400, $e->getErrors());
+        } catch (\RuntimeException $e) {
+            return JsonResponse::notFound($e->getMessage());
+        } catch (\Exception $e) {
+            return JsonResponse::serverError($e->getMessage());
+        }
+    }
+
+    /**
+     * PATCH /api/admin/users/{userId}/status
+     *
+     * Suspends (disables) or reactivates a user account. Reversible.
+     *
+     * @param array $params Route parameters (userId)
+     * @param array $body   Request body (disabled boolean)
+     * @param array $auth   Authentication context
+     */
+    public function setUserStatus(array $params, array $body, array $auth): JsonResponse
+    {
+        if (!$this->isAdmin($auth)) {
+            return JsonResponse::error('Admin privileges required', 403);
+        }
+
+        if (!array_key_exists('disabled', $body)) {
+            return JsonResponse::error('disabled is required', 400);
+        }
+
+        try {
+            $targetUserId     = (int)$params['userId'];
+            $disabled         = (bool)$body['disabled'];
+            $requestingUserId = (int)$auth['user_id'];
+
+            $result = $this->setUserStatusUseCase->execute($targetUserId, $disabled, $requestingUserId);
 
             return JsonResponse::success($result);
         } catch (ValidationException $e) {

--- a/src/Presentation/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Presentation/Middleware/ErrorHandlerMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Presentation\Middleware;
 
+use App\Application\Exception\AccountDisabledException;
 use App\Application\Exception\ValidationException;
 use App\Application\Exception\BoatNotFoundException;
 use App\Application\Exception\CrewNotFoundException;
@@ -59,6 +60,14 @@ class ErrorHandlerMiddleware
                 'message'         => $e->getMessage(),
             ]);
             return JsonResponse::notFound($e->getMessage());
+        }
+
+        // Disabled / suspended account (403 Forbidden)
+        if ($e instanceof AccountDisabledException) {
+            $this->logger->warning('http.account_disabled', [
+                'message' => $e->getMessage(),
+            ]);
+            return JsonResponse::error($e->getMessage(), 403);
         }
 
         // Blackout window (403 Forbidden)

--- a/src/Presentation/Middleware/JwtAuthMiddleware.php
+++ b/src/Presentation/Middleware/JwtAuthMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Presentation\Middleware;
 
+use App\Application\Port\Repository\UserRepositoryInterface;
 use App\Application\Port\Service\TokenServiceInterface;
 use App\Presentation\Response\JsonResponse;
 
@@ -19,7 +20,8 @@ use App\Presentation\Response\JsonResponse;
 class JwtAuthMiddleware
 {
     public function __construct(
-        private TokenServiceInterface $tokenService
+        private TokenServiceInterface $tokenService,
+        private UserRepositoryInterface $userRepository
     ) {
     }
 
@@ -54,6 +56,14 @@ class JwtAuthMiddleware
         $payload = $this->tokenService->validate($token);
 
         if ($payload === null) {
+            return null;
+        }
+
+        // Reject tokens belonging to suspended (disabled) or deleted accounts.
+        // This makes deactivation take effect immediately rather than waiting
+        // for the existing token to expire.
+        $user = $this->userRepository->findById((int)$payload['sub']);
+        if ($user === null || $user->isDisabled()) {
             return null;
         }
 

--- a/tests/Integration/Application/UseCase/Auth/LoginUseCaseTest.php
+++ b/tests/Integration/Application/UseCase/Auth/LoginUseCaseTest.php
@@ -6,6 +6,7 @@ namespace Tests\Integration\Application\UseCase\Auth;
 
 use App\Application\UseCase\Auth\LoginUseCase;
 use App\Application\DTO\Request\LoginRequest;
+use App\Application\Exception\AccountDisabledException;
 use App\Application\Exception\InvalidCredentialsException;
 use App\Application\Exception\ValidationException;
 use App\Infrastructure\Persistence\SQLite\UserRepository;
@@ -129,6 +130,57 @@ class LoginUseCaseTest extends IntegrationTestCase
         $this->expectException(InvalidCredentialsException::class);
 
         $this->useCase->execute($request);
+    }
+
+    public function testLoginWithDisabledAccountThrowsAccountDisabledException(): void
+    {
+        // Create a suspended user
+        $password = 'SecurePassword123';
+        $user = new User(
+            email: 'disabled@example.com',
+            passwordHash: $this->passwordService->hash($password),
+            accountType: 'crew',
+            isAdmin: false
+        );
+        $user->disable(new \DateTimeImmutable());
+        $this->userRepository->save($user);
+
+        // Correct credentials, but the account is disabled
+        $request = new LoginRequest(
+            email: 'disabled@example.com',
+            password: $password
+        );
+
+        $this->expectException(AccountDisabledException::class);
+
+        $this->useCase->execute($request);
+    }
+
+    public function testReactivatedAccountCanLoginAgain(): void
+    {
+        $password = 'SecurePassword123';
+        $user = new User(
+            email: 'reactivated@example.com',
+            passwordHash: $this->passwordService->hash($password),
+            accountType: 'crew',
+            isAdmin: false
+        );
+        $user->disable(new \DateTimeImmutable());
+        $this->userRepository->save($user);
+
+        // Reactivate
+        $reloaded = $this->userRepository->findById($user->getId());
+        $reloaded->reactivate();
+        $this->userRepository->save($reloaded);
+
+        $request = new LoginRequest(
+            email: 'reactivated@example.com',
+            password: $password
+        );
+
+        $response = $this->useCase->execute($request);
+
+        $this->assertNotEmpty($response->token);
     }
 
     public function testLoginWithEmptyEmailThrowsValidationException(): void

--- a/tests/Integration/Infrastructure/Persistence/SQLite/CrewRepositoryTest.php
+++ b/tests/Integration/Infrastructure/Persistence/SQLite/CrewRepositoryTest.php
@@ -189,6 +189,62 @@ class CrewRepositoryTest extends IntegrationTestCase
         $this->assertNotContains('Unavailable Test', $displayNames);
     }
 
+    public function testFindAllExcludesCrewLinkedToDisabledUser(): void
+    {
+        // Active crew (no linked user)
+        $this->createAndSaveCrew('Active', 'Member', SkillLevel::NOVICE);
+
+        // Crew linked to a disabled user
+        $user = new User(
+            email: 'suspended-crew@example.com',
+            passwordHash: 'hash',
+            accountType: 'crew',
+            isAdmin: false
+        );
+        $user->disable(new \DateTimeImmutable());
+        $this->userRepository->save($user);
+
+        $disabledCrew = $this->createTestCrew('Suspended', 'Member', SkillLevel::ADVANCED);
+        $disabledCrew->setUserId($user->getId());
+        $this->repository->save($disabledCrew);
+
+        $crews = $this->repository->findAll();
+        $displayNames = array_map(fn($c) => $c->getDisplayName(), $crews);
+
+        $this->assertContains('Active Member', $displayNames);
+        $this->assertNotContains('Suspended Member', $displayNames);
+
+        // Direct lookup still returns the crew (admin/profile views must still work)
+        $this->assertNotNull($this->repository->findByKey($disabledCrew->getKey()));
+    }
+
+    public function testFindAvailableForEventExcludesCrewLinkedToDisabledUser(): void
+    {
+        $eventId = EventId::fromString('2026-04-10');
+        $this->createTestEvent('2026-04-10', '2026-04-10');
+
+        $user = new User(
+            email: 'suspended-available@example.com',
+            passwordHash: 'hash',
+            accountType: 'crew',
+            isAdmin: false
+        );
+        $user->disable(new \DateTimeImmutable());
+        $this->userRepository->save($user);
+
+        $crew = $this->createTestCrew('SuspendedAvail', 'Member', SkillLevel::INTERMEDIATE);
+        $crew->setUserId($user->getId());
+        $this->repository->save($crew);
+
+        // Even though available, a suspended account must not be selectable
+        $this->repository->updateAvailability($crew->getKey(), $eventId, AvailabilityStatus::AVAILABLE);
+
+        $available = $this->repository->findAvailableForEvent($eventId);
+        $displayNames = array_map(fn($c) => $c->getDisplayName(), $available);
+
+        $this->assertNotContains('SuspendedAvail Member', $displayNames);
+    }
+
     public function testFindAssignedToEventReturnsOnlyGuaranteedCrew(): void
     {
         $eventId = EventId::fromString('2026-03-25');

--- a/tests/Unit/Application/UseCase/Admin/SetUserStatusUseCaseTest.php
+++ b/tests/Unit/Application/UseCase/Admin/SetUserStatusUseCaseTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Application\UseCase\Admin;
+
+use App\Application\Exception\ValidationException;
+use App\Application\Port\Repository\UserRepositoryInterface;
+use App\Application\UseCase\Admin\SetUserStatusUseCase;
+use App\Application\UseCase\Season\ProcessSeasonUpdateUseCase;
+use App\Domain\Entity\User;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class SetUserStatusUseCaseTest extends TestCase
+{
+    private function createUser(int $id, bool $disabled = false): User
+    {
+        $user = new User(
+            email: "user{$id}@example.com",
+            passwordHash: 'hashed_password',
+            accountType: 'crew',
+            isAdmin: false,
+            disabledAt: $disabled ? new \DateTimeImmutable('2026-06-01 12:00:00') : null,
+        );
+        $user->setId($id);
+
+        return $user;
+    }
+
+    private function makeUseCase(UserRepositoryInterface $userRepository): SetUserStatusUseCase
+    {
+        $season = $this->createMock(ProcessSeasonUpdateUseCase::class);
+        $season->method('execute')->willReturn(['success' => true]);
+
+        return new SetUserStatusUseCase(
+            $userRepository,
+            $season,
+            $this->createMock(LoggerInterface::class)
+        );
+    }
+
+    public function testThrowsValidationExceptionWhenTargetingOwnAccount(): void
+    {
+        $userRepository = $this->createMock(UserRepositoryInterface::class);
+        $userRepository->expects($this->never())->method('findById');
+        $userRepository->expects($this->never())->method('save');
+
+        $useCase = $this->makeUseCase($userRepository);
+
+        $this->expectException(ValidationException::class);
+
+        $useCase->execute(targetUserId: 42, disabled: true, requestingUserId: 42);
+    }
+
+    public function testThrowsRuntimeExceptionWhenUserNotFound(): void
+    {
+        $userRepository = $this->createMock(UserRepositoryInterface::class);
+        $userRepository->expects($this->once())
+            ->method('findById')
+            ->with(999)
+            ->willReturn(null);
+
+        $userRepository->expects($this->never())->method('save');
+
+        $useCase = $this->makeUseCase($userRepository);
+
+        $this->expectException(\RuntimeException::class);
+
+        $useCase->execute(targetUserId: 999, disabled: true, requestingUserId: 1);
+    }
+
+    public function testDisablesAndPersists(): void
+    {
+        $targetUser = $this->createUser(id: 5, disabled: false);
+
+        $userRepository = $this->createMock(UserRepositoryInterface::class);
+        $userRepository->method('findById')->with(5)->willReturn($targetUser);
+        $userRepository->expects($this->once())
+            ->method('save')
+            ->with($this->callback(fn($u) => $u->isDisabled() === true));
+
+        $useCase = $this->makeUseCase($userRepository);
+
+        $result = $useCase->execute(targetUserId: 5, disabled: true, requestingUserId: 1);
+
+        $this->assertTrue($targetUser->isDisabled());
+        $this->assertTrue($result['disabled']);
+        $this->assertNotNull($result['disabled_at']);
+    }
+
+    public function testReactivatesAndPersists(): void
+    {
+        $targetUser = $this->createUser(id: 5, disabled: true);
+
+        $userRepository = $this->createMock(UserRepositoryInterface::class);
+        $userRepository->method('findById')->with(5)->willReturn($targetUser);
+        $userRepository->expects($this->once())
+            ->method('save')
+            ->with($this->callback(fn($u) => $u->isDisabled() === false));
+
+        $useCase = $this->makeUseCase($userRepository);
+
+        $result = $useCase->execute(targetUserId: 5, disabled: false, requestingUserId: 1);
+
+        $this->assertFalse($targetUser->isDisabled());
+        $this->assertFalse($result['disabled']);
+        $this->assertNull($result['disabled_at']);
+    }
+
+    public function testReRunsSeasonPipelineAfterChange(): void
+    {
+        $targetUser = $this->createUser(id: 8, disabled: false);
+
+        $userRepository = $this->createMock(UserRepositoryInterface::class);
+        $userRepository->method('findById')->willReturn($targetUser);
+        $userRepository->method('save');
+
+        $season = $this->createMock(ProcessSeasonUpdateUseCase::class);
+        $season->expects($this->once())
+            ->method('execute')
+            ->willReturn(['success' => true, 'events_processed' => 2]);
+
+        $useCase = new SetUserStatusUseCase(
+            $userRepository,
+            $season,
+            $this->createMock(LoggerInterface::class)
+        );
+
+        $result = $useCase->execute(targetUserId: 8, disabled: true, requestingUserId: 1);
+
+        $this->assertSame(['success' => true, 'events_processed' => 2], $result['recalculation']);
+    }
+
+    public function testReturnedSummaryOmitsPasswordHash(): void
+    {
+        $targetUser = $this->createUser(id: 7, disabled: false);
+
+        $userRepository = $this->createMock(UserRepositoryInterface::class);
+        $userRepository->method('findById')->willReturn($targetUser);
+        $userRepository->method('save');
+
+        $useCase = $this->makeUseCase($userRepository);
+
+        $result = $useCase->execute(targetUserId: 7, disabled: true, requestingUserId: 1);
+
+        $this->assertArrayHasKey('id', $result);
+        $this->assertArrayHasKey('email', $result);
+        $this->assertArrayHasKey('disabled', $result);
+        $this->assertArrayNotHasKey('password_hash', $result);
+    }
+}

--- a/tests/Unit/Integration/IntegrationTestCaseTest.php
+++ b/tests/Unit/Integration/IntegrationTestCaseTest.php
@@ -39,7 +39,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         ")->fetchAll();
         $this->assertNotEmpty($result, 'phinxlog table should exist after running migrations');
 
-        // Verify all 9 migrations executed
+        // Verify all migrations executed
         $versions = $this->pdo->query("
             SELECT version FROM phinxlog ORDER BY version
         ")->fetchAll(PDO::FETCH_COLUMN);
@@ -53,10 +53,11 @@ class IntegrationTestCaseTest extends IntegrationTestCase
             20260224000000,  // remove_email_columns
             20260227000000,  // add_cron_notifications
             20260302000000,  // create_locks_table
-            20260316000000   // create_password_reset_tokens_table
+            20260316000000,  // create_password_reset_tokens_table
+            20260614000000   // add_user_disabled_at
         ];
 
-        $this->assertEquals($expected, $versions, 'All 9 migrations should be applied');
+        $this->assertEquals($expected, $versions, 'All migrations should be applied');
     }
 
     public function testSeasonConfigInitialized(): void

--- a/tests/Unit/Presentation/Controller/AdminControllerTest.php
+++ b/tests/Unit/Presentation/Controller/AdminControllerTest.php
@@ -17,6 +17,7 @@ use App\Application\UseCase\Admin\RemoveFromCrewWhitelistUseCase;
 use App\Application\UseCase\Admin\SendCustomNotificationUseCase;
 use App\Application\UseCase\Admin\SetCrewCommitmentRankUseCase;
 use App\Application\UseCase\Admin\SetUserAdminUseCase;
+use App\Application\UseCase\Admin\SetUserStatusUseCase;
 use App\Application\UseCase\Admin\UpdateCrewProfileUseCase;
 use App\Application\UseCase\Season\ProcessSeasonUpdateUseCase;
 use App\Application\UseCase\Season\UpdateConfigUseCase;
@@ -41,6 +42,7 @@ class AdminControllerTest extends TestCase
             $processSeasonUpdateUseCase,
             $this->createStub(GetAllUsersUseCase::class),
             $this->createStub(SetUserAdminUseCase::class),
+            $this->createStub(SetUserStatusUseCase::class),
             $this->createStub(GetUserDetailUseCase::class),
             $this->createStub(GetAllCrewsUseCase::class),
             $this->createStub(GetAllBoatsUseCase::class),


### PR DESCRIPTION
This PR is done in two commits:  one for the back-end and one for the user interface:

Admins can deactivate a boat or crew account and reactivate it later via
`PATCH /api/admin/users/{userId}/status`. Chosen over hard delete because
all accounts are purged at season end, so a reversible flag avoids
dangling-reference cleanup (partner_key, whitelist boat_key) while
preserving history for absence ranking.

Suspension is enforced at three points:
- `LoginUseCase` rejects disabled accounts after password verification
  (no status leak) via `AccountDisabledException` -> 403
- `JwtAuthMiddleware` rejects existing tokens for disabled/deleted users,
  so suspension takes effect immediately instead of at token expiry
- Crew/Boat repositories exclude accounts linked to a disabled user from
  `findAll`/`findAvailableForEvent`, keeping them out of selection and
  flotillas without touching the ranking algorithms

`SetUserStatusUseCase` guards against self-suspension and re-runs the
season pipeline so flotillas rebalance on change. `disabled` state is
surfaced in the admin user list and detail views; direct lookups remain
unaffected so admin/profile screens still see suspended accounts.

Add a reversible "Account Status" control to the admin user-edit page that
calls PATCH /api/admin/users/{userId}/status to deactivate or reactivate an
account. Deactivation prompts for confirmation and is disabled for the
admin's own account, mirroring the existing admin-rights toggle.

Surface a "Deactivated" badge and dimmed row on the admin user list so
suspended accounts are visible at a glance.

Resolves #128 